### PR TITLE
docs: improve README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,18 +56,18 @@ stop:
 	@rm -rf .tmp
 .PHONY: stop
 
-## build: Build the simapp binary into the ./build directory.
+## build-simapp: Build the simapp binary into the ./build directory.
 build-simapp: mod
 	@cd ./simapp/simd/
 	@mkdir -p build/
 	@go build $(BUILD_FLAGS) -o build/ ./simapp/simd/
-.PHONY: build
+.PHONY: build-simapp
 
-## install: Build and install the simapp binary into the $GOPATH/bin directory.
+## install-simapp: Build and install the simapp binary into the $GOPATH/bin directory.
 install-simapp:
 	@echo "--> Installing simd"
 	@go install $(BUILD_FLAGS) ./simapp/simd/
-.PHONY: install
+.PHONY: install-simapp
 
 ## mod: Update all go.mod files.
 mod:
@@ -149,7 +149,7 @@ test:
 	@go test -timeout 30m ./...
 .PHONY: test
 
-## run-simapp: Initializes a single local node network. It is useful for testing and development. Try make install && make init-simapp && simd start
+## run-simapp: Initializes a single local node network. It is useful for testing and development.
 run-simapp:
 # Warning this will remove all data in simapp home directory
 	./scripts/init-simapp.sh

--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,19 @@ help: Makefile
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
 .PHONY: help
 
+## install-dependencies: Install all dependencies needed for the demo.
 install-dependencies:
 	@echo "--> Setting up Solidity IBC Eureka submodule"
 	@cd ./solidity-ibc-eureka && bun install && just install-operator
 	@go run ./testing/demo/pkg/setup-env
 .PHONY: install-dependencies
 
-## start: spins up all processes needed for the demo
+## start: Start all processes needed for the demo.
 start: stop
 	@docker compose up -d
 .PHONY: start
 
-## setup: sets up the IBC clients and channels
+## setup: Set up the IBC clients and channels.
 setup:
 	@echo "--> Deploying tendermint light client contract on the EVM roll-up"
 	@cd ./solidity-ibc-eureka/scripts && just deploy-sp1-ics07
@@ -41,12 +42,12 @@ setup:
 	@go run ./testing/demo/pkg/setup/
 .PHONY: setup
 
-## transfer: transfers tokens from simapp network to the EVM rollup
+## transfer: Transfer tokens from simapp network to the EVM rollup.
 transfer:
 	@echo "--> Transferring tokens"
 .PHONY: transfer
 
-## stop: stops all processes and removes the tmp directory
+## stop: Stop all processes and removes the tmp directory.
 stop:
 	@echo "--> Stopping all processes"
 	@docker compose down
@@ -153,4 +154,3 @@ run-simapp:
 # Warning this will remove all data in simapp home directory
 	./scripts/init-simapp.sh
 .PHONY: run-simapp
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZK-EVM X Celestia Token Transfer Demo
 
-> ⚠️ **Warning**
+> [!WARNING]
 > This repository is a work in progress and under active development.
 
 This repo exists to showcase transferring tokens to and from a Cosmos SDK chain (representing Celestia) and a ZK proveable EVM using the [IBC-Eureka solidity contracts](https://github.com/cosmos/solidity-ibc-eureka/blob/main/README.md). The diagram below is meant to detail the components involved and, at a high level, how they interact with one another.
@@ -30,7 +30,7 @@ For more information refer to the [architecture document](./ARCHITECTURE.md). No
     git submodule update
     ```
 
-1. Install contract dependencies and sp1 tendermint light client operator binary in solidity-ibc-eureka which is a requirement before deploying contracts
+1. Install contract dependencies and the SP1 Tendermint light client operator binary from solidity-ibc-eureka.
 
     ```shell
     make install-dependencies
@@ -42,17 +42,15 @@ For more information refer to the [architecture document](./ARCHITECTURE.md). No
     make start
     ```
 
-    > [!TIP]: Double check that all 5 containers are started. Currently: the bridge might fail because it depends on the validator being available. If this happens, wait until the validator is available then start the bridge and beacond node again.
-
-1. Set up IBC Clients and Channels:
+1. Set up IBC clients and channels:
 
     - Generate the `contracts/script/genesis.json` file which contains the initialization parameters for the `SP1ICS07Tendermint` light client contract.
     - Initialize Groth16 light client on simapp.
     - Create a channel on simapp.
     - Deploy IBC contracts on the Reth node.
-    - Create a channel on the reth node.
-    - Create a counterparty on the reth node. (it will be pointing to groth16 client ID on simapp)
-    - Create a counterparty on the simapp. (it will be pointing to tendermint client ID on reth)
+    - Create a channel on the Reth node.
+    - Create a counterparty on the Reth node which points to the groth16 client ID on simapp.
+    - Create a counterparty on the simapp which points to the tendermint client ID on Reth.
 
     ```shell
     make setup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Stage 1: generate txsim binary
+# Stage 1: Generate the simapp binary (simd)
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.1-alpine3.20 as builder
 
 ARG TARGETOS
@@ -21,7 +21,7 @@ RUN uname -a &&\
     CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     make build
 
-# Stage 2: create a minimal image with the binary
+# Stage 2: Create a minimal image with just the binary
 FROM docker.io/alpine:3.20
 
 # Use UID 10,001 because UIDs below 10,000 are a security risk.
@@ -45,7 +45,7 @@ RUN apk update && apk add --no-cache \
     -s /sbin/nologin \
     -u ${UID}
 
-# Copy in the txsim binary
+# Copy in the simd binary
 COPY --from=builder /celestia_zkevm_ibc_demo/build/simd /bin/simd
 
 USER ${USER_NAME}


### PR DESCRIPTION
I noticed the `install-dependencies` command didn't show up in `make help` output. Fixed a few other small things while reviewing it.