### PR TITLE
fix: celestia prover connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,13 +103,17 @@ services:
     image: ghcr.io/celestiaorg/celestia-zkevm-ibc-demo/celestia-prover:latest
     container_name: celestia-prover
     environment:
-      - TENDERMINT_RPC_URL=http://celestia-network-validator:26657
+      # TENDERMINT_RPC_URL should be the SimApp which is acting as a substitute
+      # for Celestia (with IBC Eurekea enabled).
+      - TENDERMINT_RPC_URL=http://simapp-validator:26657
       - RPC_URL=http://reth:8545
     ports:
       - "50051:50051"
     depends_on:
       beacond:
         condition: service_started
+    networks:
+      - beacon-network
 
 networks:
   beacon-network:


### PR DESCRIPTION
Prior to this PR the celestia-prover wasn't in the same Docker network as the other services so it couldn't connect to the Reth node or SimApp. Also it was trying to use the Celestia validator instead of SimApp validator.