### PR TITLE
chore(deps): upgrade to SP1 v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
  "alloy-sol-macro-input 0.7.7",
  "const-hex",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.7.0",
  "proc-macro-error",
  "proc-macro2",
@@ -661,7 +661,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input 0.8.15",
  "const-hex",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.7.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -679,7 +679,7 @@ checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
 dependencies = [
  "const-hex",
  "dunce",
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -695,7 +695,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1459,6 +1459,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap 2.7.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.90",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +1507,7 @@ dependencies = [
  "serde_cbor",
  "sp1-ics07-tendermint-prover",
  "sp1-ics07-tendermint-utils",
- "sp1-prover",
+ "sp1-prover 4.0.1",
  "sp1-sdk",
  "tendermint-rpc",
  "tokio",
@@ -1580,7 +1599,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -1729,6 +1748,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1911,6 +1939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2040,6 +2069,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downloader"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand",
+ "reqwest 0.12.9",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2149,7 @@ dependencies = [
  "ff 0.13.0",
  "generic-array 0.14.7",
  "group 0.13.0",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -2738,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb8bc4c28d15ade99c7e90b219f30da4be5c88e586277e8cbe886beeb868ab2"
+checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
 dependencies = [
  "serde",
  "typenum",
@@ -2929,6 +2973,12 @@ checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -4125,7 +4175,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4262,13 +4312,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "p3-air"
 version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066f571b2e645505ed5972dd0e1e252ba03352150830c9566769ca711c0f1e9b"
 dependencies = [
- "p3-field",
- "p3-matrix",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+]
+
+[[package]]
+name = "p3-air"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02634a874a2286b73f3e0a121e79d6774e92ccbec648c5568f4a7479a4830858"
+dependencies = [
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
 ]
 
 [[package]]
@@ -4278,10 +4350,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff00f571044d299310d9659c6e51c98422de3bf94b8577f7f30cf59cf2043e40"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.4-succinct",
+ "p3-mds 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080896e9d09e9761982febafe3b3da5cbf320e32f0c89b6e2e01e875129f4c2d"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field 0.2.0-succinct",
+ "p3-mds 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
  "rand",
  "serde",
 ]
@@ -4293,7 +4380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4cb69ae54a279bbbd477566d1bdb71aa879b528fd658d0fcfc36f54b00217c"
 dependencies = [
  "blake3",
- "p3-symmetric",
+ "p3-symmetric 0.1.4-succinct",
 ]
 
 [[package]]
@@ -4304,9 +4391,24 @@ checksum = "bf19917f986d45e9abb6d177e875824ced6eed096480d574fce16f2c45c721ea"
 dependencies = [
  "ff 0.13.0",
  "num-bigint 0.4.6",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-bn254-fr"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c53da73873e24d751ec3bd9d8da034bb5f99c71f24f4903ff37190182bff10"
+dependencies = [
+ "ff 0.13.0",
+ "num-bigint 0.4.6",
+ "p3-field 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
  "rand",
  "serde",
 ]
@@ -4317,10 +4419,24 @@ version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be7e4fbce4566a93091107eadfafa0b5374bd1ffd3e0f6b850da3ff72eb183f"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f5c497659a7d9a87882e30ee9a8d0e20c8dcd32cd10d432410e7d6f146ef103"
+dependencies = [
+ "p3-field 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "serde",
  "tracing",
 ]
@@ -4332,11 +4448,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a03eb0f99d68a712c41e658e9a7782a0705d4ffcfb6232a43bd3f1ef9591002"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-challenger 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "serde",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ec340c5cb17739a7b9ee189378bdac8f0e684b9b5ce539476c26e77cd6a27d"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "serde",
 ]
 
@@ -4346,10 +4476,23 @@ version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1556de968523fbe5d804ab50600ea306fcceea3500cfd7601e40882480524664"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292e97d02d4c38d8b306c2b8c0428bf15f4d32a11a40bcf80018f675bf33267e"
+dependencies = [
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "tracing",
 ]
 
@@ -4362,7 +4505,21 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util",
+ "p3-util 0.1.4-succinct",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91d8e5f9ede1171adafdb0b6a0df1827fbd4eb6a6217bfa36374e5d86248757"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-util 0.2.0-succinct",
  "rand",
  "serde",
 ]
@@ -4374,14 +4531,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f351ee9f9d4256455164565cd91e3e6d2487cc2a5355515fa2b6d479269188dd"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-interpolation 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef838ff24d9b3de3d88d0ac984937d2aa2923bf25cb108ba9b2dc357e472197"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-interpolation 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "serde",
  "tracing",
 ]
@@ -4392,9 +4568,20 @@ version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24d0f2907a374ebe4545fcff3120d6376d9630cf0bef30feedcfc5908ea2c37"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c806c3afb8d6acf1d3a78f4be1e9e8b026f13c01b0cdd5ae2e068b70a3ba6d80"
+dependencies = [
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
 ]
 
 [[package]]
@@ -4403,11 +4590,25 @@ version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66badd47cedf6570e91a0cabc389b80dfd53ba1a6e9a45a3923fd54b86122ff"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "tracing",
+]
+
+[[package]]
+name = "p3-keccak-air"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46cef7ee8ae1f7cb560e7b7c137e272f6ba75be98179b3aa18695705231e0fb"
+dependencies = [
+ "p3-air 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "tracing",
 ]
 
@@ -4418,9 +4619,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa272f3ae77ed8d73478aa7c89e712efb15bda3ff4aff10fadfe11a012cd5389"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "rand",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98bf2c7680b8e906a5e147fe4ceb05a11cc9fa35678aa724333bcb35c72483c1"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "rand",
  "serde",
  "tracing",
@@ -4436,17 +4652,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-maybe-rayon"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9ac6f1d11ad4d3c13cc496911109d6282315e64f851a666ed80ad4d77c0983"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "p3-mds"
 version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "716c4dbe68a02f1541eb09149d07b8663a3a5951b1864a31cd67ff3bb0826e57"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "rand",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706cea48976f54702dc68dffa512684c1304d1a3606cadea423cfe0b1ee25134"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "rand",
 ]
 
@@ -4457,12 +4697,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad7ebab52a03c26025988663a135aed62f5084a2e2ea262176dc8748efb593e5"
 dependencies = [
  "itertools 0.12.1",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-commit 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ced385da80dd6b3fd830eaa452c9fa899f2dc3f6463aceba00620d5f071ec"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-commit 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "serde",
  "tracing",
 ]
@@ -4474,9 +4731,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39c042efa15beab7a8c4d0ca9b9e4cbda7582be0c08e121e830fec45f082935b"
 dependencies = [
  "gcd",
- "p3-field",
- "p3-mds",
- "p3-symmetric",
+ "p3-field 0.1.4-succinct",
+ "p3-mds 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ce5f5ec7f1ba3a233a671621029def7bd416e7c51218c9d1167d21602cf312"
+dependencies = [
+ "gcd",
+ "p3-field 0.2.0-succinct",
+ "p3-mds 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
  "rand",
  "serde",
 ]
@@ -4488,7 +4759,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9896a831f5b688adc13f6fbe1dcf66ecfaa4622a500f81aa745610e777acb72"
 dependencies = [
  "itertools 0.12.1",
- "p3-field",
+ "p3-field 0.1.4-succinct",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f29dc5bb6c99d3de75869d5c086874b64890280eeb7d3e068955f939e219253"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field 0.2.0-succinct",
  "serde",
 ]
 
@@ -4499,14 +4781,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8437ebcd060c8a5479898030b114a93da8a86eb4c2e5f313d9eeaaf40c6e6f61"
 dependencies = [
  "itertools 0.12.1",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.1.4-succinct",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-uni-stark"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ceaeef06b0bc97e5af2d220cd340b0b3a72bdf37e4584b73b3bc357cfc9ed3"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-air 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
  "serde",
  "tracing",
 ]
@@ -4516,6 +4817,15 @@ name = "p3-util"
 version = "0.1.4-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dedb9d27ba47ac314c6fac4ca54e55c3e486c864d51ec5ba55dbe47b75121157"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.2.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b84d324cd4ac09194a9d0e8ab1834e67a0e47dec477c28fcf9d68b2824c1fe"
 dependencies = [
  "serde",
 ]
@@ -4615,6 +4925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,6 +4983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4783,6 +5108,15 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4909,7 +5243,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -5000,7 +5334,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6019,16 +6353,55 @@ dependencies = [
  "log",
  "nohash-hasher",
  "num",
- "p3-field",
- "p3-maybe-rayon",
+ "p3-field 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
  "rand",
  "rrs-succinct",
  "serde",
- "sp1-curves",
- "sp1-primitives",
- "sp1-stark",
+ "sp1-curves 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-stark 3.4.0",
  "strum",
  "strum_macros",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typenum",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-core-executor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8ec5621fba6c50f6ec4e0e963227d1ab2229840b0e210a57e1f18428bbcbc8"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "clap",
+ "elf",
+ "enum-map",
+ "eyre",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.13.0",
+ "log",
+ "nohash-hasher",
+ "num",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "rand",
+ "rrs-succinct",
+ "serde",
+ "serde_json",
+ "sp1-curves 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-stark 4.0.1",
+ "strum",
+ "strum_macros",
+ "subenum",
  "thiserror 1.0.69",
  "tiny-keccak",
  "tracing",
@@ -6045,7 +6418,7 @@ dependencies = [
  "bincode",
  "cfg-if",
  "elliptic-curve",
- "generic-array 1.1.1",
+ "generic-array 1.1.0",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
@@ -6053,25 +6426,82 @@ dependencies = [
  "log",
  "num",
  "num_cpus",
- "p3-air",
- "p3-baby-bear",
+ "p3-air 0.1.4-succinct",
+ "p3-baby-bear 0.1.4-succinct",
  "p3-blake3",
- "p3-challenger",
- "p3-field",
- "p3-keccak-air",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-uni-stark",
- "p3-util",
+ "p3-challenger 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-keccak-air 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-uni-stark 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "rand",
  "serde",
  "size",
  "snowbridge-amcl",
- "sp1-core-executor",
- "sp1-curves",
- "sp1-derive",
- "sp1-primitives",
- "sp1-stark",
+ "sp1-core-executor 3.4.0",
+ "sp1-curves 3.4.0",
+ "sp1-derive 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-stark 3.4.0",
+ "static_assertions",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber",
+ "typenum",
+ "web-time",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96b1962e6c10ac8321c9ea16161467ca27b43a75c02f42c82310d5e05768f5"
+dependencies = [
+ "bincode",
+ "cbindgen",
+ "cc",
+ "cfg-if",
+ "elliptic-curve",
+ "generic-array 1.1.0",
+ "glob",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.13.0",
+ "k256",
+ "log",
+ "num",
+ "num_cpus",
+ "p256",
+ "p3-air 0.2.0-succinct",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-keccak-air 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-uni-stark 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "pathdiff",
+ "rand",
+ "rayon",
+ "rayon-scan",
+ "serde",
+ "serde_json",
+ "size",
+ "snowbridge-amcl",
+ "sp1-core-executor 4.0.1",
+ "sp1-curves 4.0.1",
+ "sp1-derive 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-stark 4.0.1",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -6093,15 +6523,37 @@ dependencies = [
  "cfg-if",
  "dashu",
  "elliptic-curve",
- "generic-array 1.1.1",
+ "generic-array 1.1.0",
  "itertools 0.13.0",
  "k256",
  "num",
- "p3-field",
+ "p3-field 0.1.4-succinct",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives",
- "sp1-stark",
+ "sp1-primitives 3.4.0",
+ "sp1-stark 3.4.0",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-curves"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849790f9a7b713fea00a0ec0ccfca13f2cea86249c33d38851c8ee75e0d8d78"
+dependencies = [
+ "cfg-if",
+ "dashu",
+ "elliptic-curve",
+ "generic-array 1.1.0",
+ "itertools 0.13.0",
+ "k256",
+ "num",
+ "p256",
+ "p3-field 0.2.0-succinct",
+ "serde",
+ "snowbridge-amcl",
+ "sp1-primitives 4.0.1",
+ "sp1-stark 4.0.1",
  "typenum",
 ]
 
@@ -6110,6 +6562,16 @@ name = "sp1-derive"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf59bbd55ee20f0decb602809aadc73f09defb6f6d27067acf16029e84191b4a"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sp1-derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d988a16a181f3f641677cbe6a98154effc0f22befb8d14470ba1697ddfda4c9"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6181,10 +6643,28 @@ dependencies = [
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b25a09b455dfae9c688da05718b205e8bd4afab36cd912d54639f5d4035815"
+dependencies = [
+ "bincode",
+ "hex",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
  "serde",
  "sha2 0.10.8",
 ]
@@ -6204,30 +6684,73 @@ dependencies = [
  "lazy_static",
  "lru",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-bn254-fr 0.1.4-succinct",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
  "rayon",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serial_test",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-recursion-circuit",
- "sp1-recursion-compiler",
- "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
- "sp1-stark",
+ "sp1-core-executor 3.4.0",
+ "sp1-core-machine 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-recursion-circuit 3.4.0",
+ "sp1-recursion-compiler 3.4.0",
+ "sp1-recursion-core 3.4.0",
+ "sp1-recursion-gnark-ffi 3.4.0",
+ "sp1-stark 3.4.0",
  "subtle-encoding",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sp1-prover"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d5713392e803b1e609d626256015ddb5464e2f435fc55fa8f383bae111a4af"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "clap",
+ "dirs",
+ "downloader",
+ "eyre",
+ "hex",
+ "itertools 0.13.0",
+ "lru",
+ "num-bigint 0.4.6",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-bn254-fr 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2 0.10.8",
+ "sp1-core-executor 4.0.1",
+ "sp1-core-machine 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-recursion-circuit 4.0.1",
+ "sp1-recursion-compiler 4.0.1",
+ "sp1-recursion-core 4.0.1",
+ "sp1-recursion-gnark-ffi 4.0.1",
+ "sp1-stark 4.0.1",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -6240,28 +6763,62 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-air 0.1.4-succinct",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-bn254-fr 0.1.4-succinct",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-fri 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "rand",
  "rayon",
  "serde",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
- "sp1-recursion-compiler",
- "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
- "sp1-stark",
+ "sp1-core-executor 3.4.0",
+ "sp1-core-machine 3.4.0",
+ "sp1-derive 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-recursion-compiler 3.4.0",
+ "sp1-recursion-core 3.4.0",
+ "sp1-recursion-gnark-ffi 3.4.0",
+ "sp1-stark 3.4.0",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-circuit"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe6fcf68661a7253c9b7bf253b35c40a641b25d09048c5ac2c549e320428cd5"
+dependencies = [
+ "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "num-traits",
+ "p3-air 0.2.0-succinct",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-bn254-fr 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-fri 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "rand",
+ "rayon",
+ "serde",
+ "sp1-core-executor 4.0.1",
+ "sp1-core-machine 4.0.1",
+ "sp1-derive 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-recursion-compiler 4.0.1",
+ "sp1-recursion-core 4.0.1",
+ "sp1-recursion-gnark-ffi 4.0.1",
+ "sp1-stark 4.0.1",
  "tracing",
 ]
 
@@ -6273,16 +6830,38 @@ checksum = "673d2c66a48e6d17e1165b5ea38b59de5e80bf64fd45f17ebc9d75e67c4ff414"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-field",
- "p3-symmetric",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-bn254-fr 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
  "serde",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-recursion-core",
- "sp1-recursion-derive",
- "sp1-stark",
+ "sp1-core-machine 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-recursion-core 3.4.0",
+ "sp1-recursion-derive 3.4.0",
+ "sp1-stark 3.4.0",
+ "tracing",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-recursion-compiler"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efb23c5b5266e07debb0a0d9a0cc4dcc03b646937a80a7b73d4696ccc9a7152"
+dependencies = [
+ "backtrace",
+ "itertools 0.13.0",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-bn254-fr 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "serde",
+ "sp1-core-machine 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-recursion-core 4.0.1",
+ "sp1-recursion-derive 4.0.1",
+ "sp1-stark 4.0.1",
  "tracing",
  "vec_map",
 ]
@@ -6297,25 +6876,68 @@ dependencies = [
  "ff 0.13.0",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-air 0.1.4-succinct",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-bn254-fr 0.1.4-succinct",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-fri 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-merkle-tree 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "serde",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
- "sp1-stark",
+ "sp1-core-machine 3.4.0",
+ "sp1-derive 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-stark 3.4.0",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+ "vec_map",
+ "zkhash",
+]
+
+[[package]]
+name = "sp1-recursion-core"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2267c384a2106cb5b3235a8b02fa5d91db30c1bfead653f6181d1a17f91c70b2"
+dependencies = [
+ "backtrace",
+ "cbindgen",
+ "cc",
+ "cfg-if",
+ "ff 0.13.0",
+ "glob",
+ "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "num_cpus",
+ "p3-air 0.2.0-succinct",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-bn254-fr 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-fri 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-merkle-tree 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "pathdiff",
+ "rand",
+ "serde",
+ "sp1-core-machine 4.0.1",
+ "sp1-derive 4.0.1",
+ "sp1-primitives 4.0.1",
+ "sp1-stark 4.0.1",
  "static_assertions",
  "thiserror 1.0.69",
  "tracing",
@@ -6328,6 +6950,16 @@ name = "sp1-recursion-derive"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3125726165ff77fb2650ae031075ba747099a6e218e5c10f84ac2715545a2332"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sp1-recursion-derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe45973782801df096675f29dabbceeaf121b5b9875411f2bad245f128a7b72"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6347,15 +6979,41 @@ dependencies = [
  "hex",
  "log",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-symmetric",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sp1-core-machine",
- "sp1-recursion-compiler",
- "sp1-stark",
+ "sp1-core-machine 3.4.0",
+ "sp1-recursion-compiler 3.4.0",
+ "sp1-stark 3.4.0",
+ "tempfile",
+]
+
+[[package]]
+name = "sp1-recursion-gnark-ffi"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cc97057e5240a2ab3062234a60d6ee6dbdb852ef02ea5fe5f943f910f6c9e"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "hex",
+ "log",
+ "num-bigint 0.4.6",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sp1-core-machine 4.0.1",
+ "sp1-recursion-compiler 4.0.1",
+ "sp1-stark 4.0.1",
  "tempfile",
 ]
 
@@ -6378,18 +7036,18 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "log",
- "p3-baby-bear",
- "p3-field",
- "p3-fri",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-fri 0.1.4-succinct",
  "prost",
  "reqwest 0.12.9",
  "reqwest-middleware",
  "serde",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-prover",
- "sp1-stark",
+ "sp1-core-executor 3.4.0",
+ "sp1-core-machine 3.4.0",
+ "sp1-primitives 3.4.0",
+ "sp1-prover 3.4.0",
+ "sp1-stark 3.4.0",
  "strum",
  "strum_macros",
  "tempfile",
@@ -6411,28 +7069,63 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
+ "p3-air 0.1.4-succinct",
+ "p3-baby-bear 0.1.4-succinct",
+ "p3-challenger 0.1.4-succinct",
+ "p3-commit 0.1.4-succinct",
+ "p3-dft 0.1.4-succinct",
+ "p3-field 0.1.4-succinct",
+ "p3-fri 0.1.4-succinct",
+ "p3-matrix 0.1.4-succinct",
+ "p3-maybe-rayon 0.1.4-succinct",
+ "p3-merkle-tree 0.1.4-succinct",
+ "p3-poseidon2 0.1.4-succinct",
+ "p3-symmetric 0.1.4-succinct",
+ "p3-uni-stark 0.1.4-succinct",
+ "p3-util 0.1.4-succinct",
  "rayon-scan",
  "serde",
- "sp1-derive",
- "sp1-primitives",
+ "sp1-derive 3.4.0",
+ "sp1-primitives 3.4.0",
  "strum",
  "strum_macros",
  "sysinfo",
  "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-stark"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274d0cddd1804a447daaf29deeb2ce46a5c808c626261daf710da8b90bb25f99"
+dependencies = [
+ "arrayref",
+ "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-air 0.2.0-succinct",
+ "p3-baby-bear 0.2.0-succinct",
+ "p3-challenger 0.2.0-succinct",
+ "p3-commit 0.2.0-succinct",
+ "p3-dft 0.2.0-succinct",
+ "p3-field 0.2.0-succinct",
+ "p3-fri 0.2.0-succinct",
+ "p3-matrix 0.2.0-succinct",
+ "p3-maybe-rayon 0.2.0-succinct",
+ "p3-merkle-tree 0.2.0-succinct",
+ "p3-poseidon2 0.2.0-succinct",
+ "p3-symmetric 0.2.0-succinct",
+ "p3-uni-stark 0.2.0-succinct",
+ "p3-util 0.2.0-succinct",
+ "rayon-scan",
+ "serde",
+ "sp1-derive 4.0.1",
+ "sp1-primitives 4.0.1",
+ "strum",
+ "strum_macros",
+ "sysinfo",
  "tracing",
 ]
 
@@ -6506,11 +7199,23 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "subenum"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5d5dfb8556dd04017db5e318bbeac8ab2b0c67b76bf197bfb79e9b29f18ecf"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7171,6 +7876,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/provers/celestia-prover/Cargo.toml
+++ b/provers/celestia-prover/Cargo.toml
@@ -20,7 +20,7 @@ sp1-ics07-tendermint-utils.workspace = true
 ibc-core-commitment-types = { workspace = true }
 dotenv = "0.15.0"
 anyhow = "1.0.94"
-sp1-prover = "3.4.0"
+sp1-prover = "4.0.0"
 bincode = "1.3.3"
 sp1-sdk = { workspace = true, features = ["network"] }
 ibc-proto = { workspace = true }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/87

## Testing

```
make start
make setup
make transfer
make relay
```

Generated a proof that was able to update the Tendermint light client on EVM