### PR TITLE
fix(blevm): groth16 instead of core proofs

### DIFF
--- a/provers/blevm/blevm-prover/src/lib.rs
+++ b/provers/blevm/blevm-prover/src/lib.rs
@@ -224,7 +224,7 @@ impl BlockProver {
         // Generate and return the proof
         let client = ProverClient::from_env();
         let (pk, _) = client.setup(self.prover_config.elf_bytes);
-        let proof = client.prove(&pk, &stdin).core().run()?;
+        let proof = client.prove(&pk, &stdin).groth16().run()?;
 
         bincode::serialize(&proof).map_err(|e| e.into())
     }


### PR DESCRIPTION
As the error message suggests, switching to groth16 proofs fixed the issue:

> Error: status: InvalidArgument, message: "core proofs above 5000000 cycles are not supported - please request a compressed, groth16, or plonk proof instead", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Wed, 29 Jan 2025 06:32:45 GMT", "content-type": "application/grpc", "content-length": "0", "access-control-allow-origin": "*", "vary": "origin, access-control-request-method, access-control-request-headers"} }


Fixes #113 
