### PR TITLE
docs: measure proof generation time

### DIFF
--- a/provers/blevm/README.md
+++ b/provers/blevm/README.md
@@ -76,3 +76,11 @@ The `script` binary will generate an SP1 proof but it depends on a DA node. You 
     +   elf_bytes: include_elf!("blevm-mock"),
     };
     ```
+
+## FAQ
+
+How long does it take to generate a proof?
+
+| Proof | Time      | SP1_PROVER |
+|-------|-----------|------------|
+| blevm | 6 minutes | network    |

--- a/provers/blevm/script/src/bin/main.rs
+++ b/provers/blevm/script/src/bin/main.rs
@@ -2,6 +2,7 @@ use blevm_prover::{BlockProver, BlockProverInput, CelestiaClient, CelestiaConfig
 use celestia_types::nmt::Namespace;
 use sp1_sdk::{include_elf, utils};
 use std::{error::Error, fs};
+use std::time::Instant;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -41,11 +42,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         l2_block_data: fs::read("input/1/18884864.bin")?,
     };
 
-    // Generate proof
     println!("Generating proof...");
+    let start = Instant::now();
     let proof = prover.generate_proof(input).await?;
+    let duration = start.elapsed();
+    println!("Generated proof in {:?}.", duration);
+
     // Save proof to file
+    println!("Saving proof to proof.bin");
     fs::write("proof.bin", proof)?;
+    println!("Saved proof.");
 
     Ok(())
 }


### PR DESCRIPTION
## Context

Now that we can generate blevm proofs, I wanted to measure the proof generation time to double check that we actually need the mock proofs. It takes 6 minutes so seems worth pursuing the mock proofs for now.

## Testing

```
Generating proof...
stderr: WARNING: Using insecure random number generator.
stdout: Blob commitment: 7946cf528edd745efb25201246e647d5aaca3fb52bf0f606b695b4ab0bd33f4c
Generated proof in 348.35040425s.
Saving proof to proof.bin
Saved proof.
```