### PR TITLE
chore(docker): ignore all target directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .tmp
 build
-/target
 *.bin
+
+# Ignore all target directories
+**/target/


### PR DESCRIPTION
I was trying to build a celestia-prover Docker image and it took forever transferring over 20 GB of context. It appears to have been copying nested `target/` directories inside the blevm subdirectory. This change makes Docker ignore all the target directories, not just the one at the repo root. 