### PR TITLE
fix: warning for unused manifest key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ ibc-core-commitment-types = "0.56"
 sp1-sdk = { version = "4.0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 
-ibc-eureka-solidity-types = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main", subdir = "packages/solidity", features = [
+ibc-eureka-solidity-types = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main", features = [
     "rpc",
 ] }
-sp1-ics07-tendermint-prover = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main", subdir = "packages/prover" }
-sp1-ics07-tendermint-utils = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main", subdir = "packages/utils" }
+sp1-ics07-tendermint-prover = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main"}
+sp1-ics07-tendermint-utils = { git = "https://github.com/cosmos/solidity-ibc-eureka.git", branch = "main"}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/136

The `subdir` key wasn't necessary:

> Cargo fetches the git repository at that location and traverses the file tree to find Cargo.toml file for the requested crate anywhere inside the git repository.

Ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html


## Testing

No more warnings 

```
$ cargo build
   Compiling sp1-ics07-tendermint-prover v0.1.0 (https://github.com/cosmos/solidity-ibc-eureka.git?branch=main#ec5227e7)
   Compiling mock-membership v0.1.0 (/Users/rootulp/git/rootulp/celestiaorg/celestia-zkevm-ibc-demo/programs/sp1/mock-membership)
   Compiling mock-update-client v0.1.0 (/Users/rootulp/git/rootulp/celestiaorg/celestia-zkevm-ibc-demo/programs/sp1/mock-update-client)
   Compiling celestia-prover v0.1.0 (/Users/rootulp/git/rootulp/celestiaorg/celestia-zkevm-ibc-demo/provers/celestia-prover)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.38s
$ cargo run -p celestia-prover
   Compiling celestia-prover v0.1.0 (/Users/rootulp/git/rootulp/celestiaorg/celestia-zkevm-ibc-demo/provers/celestia-prover)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.08s
     Running `target/debug/celestia-prover`
```