### PR TITLE
docs: fix Succinct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information refer to the [architecture document](./ARCHITECTURE.md). No
 1. Install [Foundry](https://book.getfoundry.sh/getting-started/installation)
 1. Install [Bun](https://bun.sh/)
 1. Install [Just](https://just.systems/man/en/)
-1. Install [SP1](https://docs.succinct.xyz/docs/getting-started/install)
+1. Install [SP1](https://docs.succinct.xyz/docs/sp1/getting-started/install)
 
 ### Steps
 

--- a/provers/blevm/README.md
+++ b/provers/blevm/README.md
@@ -15,7 +15,7 @@ This workspace contains multiple crates:
 
 ## Contributing
 
-See <https://docs.succinct.xyz/docs/introduction>
+See <https://docs.succinct.xyz/docs/sp1/introduction>
 
 ### Prerequisites
 
@@ -77,7 +77,7 @@ The `script` binary will generate an SP1 proof but it depends on a DA node. You 
 
 ### Development
 
-While developing SP1 programs (i.e. `blevm`, `blevm-mock`, `blevm-aggregate`) it is helpful to generate [development builds](https://docs.succinct.xyz/docs/writing-programs/compiling#development-builds):
+While developing SP1 programs (i.e. `blevm`, `blevm-mock`, `blevm-aggregate`) it is helpful to generate [development builds](https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#development-builds):
 
 ```shell
 # Change to an SP1 program crate


### PR DESCRIPTION
Hi! The links were pointing to outdated or incorrect URLs related to Succinct's SP1 documentation.