### PR TITLE
fix: fix handling of filenames with spaces or special characters

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -6,7 +6,7 @@ cd proto
 proto_dirs=$(find . -path ./cosmos -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    if grep "option go_package" $file &> /dev/null ; then
+    if grep "option go_package" "$file" &> /dev/null ; then
       buf generate --template buf.gen.gogo.yaml $file
     fi
   done


### PR DESCRIPTION
## Overview

I’ve fixed an issue where the `$file` variable wasn't properly quoted, causing errors when processing filenames with spaces or special characters.

Now, the variable is enclosed in double quotes to ensure that such filenames are handled correctly without causing issues.
