### PR TITLE
chore: emit more logs from celestia-prover

### DIFF
--- a/provers/celestia-prover/prover/src/main.rs
+++ b/provers/celestia-prover/prover/src/main.rs
@@ -186,7 +186,6 @@ impl Prover for ProverService {
             trusted_block.signed_header.header.height.value() as i64
         );
 
-        // Implement your membership proof logic here
         let response = ProveStateMembershipResponse {
             proof: proof.bytes().to_vec(),
             height: trusted_block.signed_header.header.height.value() as i64,

--- a/provers/celestia-prover/prover/src/main.rs
+++ b/provers/celestia-prover/prover/src/main.rs
@@ -141,7 +141,7 @@ impl Prover for ProverService {
             proof: proof.bytes().to_vec(),
             public_values: proof.public_values.to_vec(),
         };
-        println!("generated proof");
+        println!("Generated state transition proof.");
 
         Ok(Response::new(response))
     }

--- a/provers/celestia-prover/prover/src/prover.rs
+++ b/provers/celestia-prover/prover/src/prover.rs
@@ -1,5 +1,7 @@
 //! Prover for SP1 ICS07 Tendermint programs.
 
+use std::env;
+
 use crate::programs::{MembershipProgram, SP1Program, UpdateClientProgram};
 use alloy_sol_types::SolValue;
 use ibc_client_tendermint_types::Header;
@@ -39,6 +41,9 @@ impl<T: SP1Program> SP1ICS07TendermintProver<T> {
     #[tracing::instrument(skip_all)]
     pub fn new(proof_type: SupportedProofType) -> Self {
         tracing::info!("Initializing SP1 ProverClient...");
+        if let Ok(mode) = env::var("SP1_PROVER") {
+            println!("SP1_Prover mode: {mode}");
+        };
         let prover_client = ProverClient::from_env();
         let (pkey, vkey) = prover_client.setup(T::ELF);
         tracing::info!("SP1 ProverClient initialized");


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/86

## Testing

```
$ cargo run -p celestia-prover
SP1_Prover mode: network
```

It already logs when it finishes generating proofs. Ex:

```
Generated membership proof for height: 12039
```