### PR TITLE
fix(blevm): fix blevm output

### DIFF
--- a/provers/blevm/blevm/src/main.rs
+++ b/provers/blevm/blevm/src/main.rs
@@ -110,8 +110,7 @@ pub fn main() {
         state_root: header.state_root.into(),
         celestia_header_hash: celestia_header_hash.as_bytes().try_into().unwrap(),
     };
-    let serialized_output = bincode::serialize(&output).unwrap();
-    sp1_zkvm::io::commit(&serialized_output);
+    sp1_zkvm::io::commit(&output);
 
     println!(
         "cycle-tracker-end: hashing the block header, and commiting its fields as public values"


### PR DESCRIPTION
## Overview

The sp1 program output is [serialized by default](https://docs.succinct.xyz/docs/sp1/writing-programs/inputs-and-outputs#committing-data
), serializing it before commiting it causes issues while reading the output, e.g. interchanged height and gas used. There were other discrepancies as well, such as header not matching the expected evm header.

Before:

```
cd provers/blevm/script
cargo run -- --execute
```
> BlevmOutput { blob_commitment: [196, 0, 0, 0, 0, 0, 0, 0, 121, 70, 207, 82, 142, 221, 116, 94, 251, 37, 32, 18, 70, 230, 71, 213, 170, 202, 63, 181, 43, 240, 246, 6], header_hash: [182, 149, 180, 171, 11, 211, 63, 76, 133, 106, 134, 184, 20, 76, 104, 254, 40, 136, 41, 140, 238, 199, 193, 86, 163, 56, 170, 193, 61, 146, 213, 227], prev_header_hash: [194, 70, 12, 164, 151, 147, 237, 105, 187, 154, 187, 153, 78, 140, 25, 59, 84, 254, 152, 25, 224, 239, 83, 45, 145, 73, 226, 110, 100, 51, 95, 167], **height: 14900876081506838043, gas_used: 18884864**, beneficiary: [4, 26, 65, 0, 0, 0, 0, 0, 149, 34, 34, 144, 221, 114, 120, 170, 61, 221, 56, 156], state_root: [193, 225, 209, 101, 204, 75, 175, 229, 27, 56, 213, 58, 25, 68, 72, 76, 140, 126, 48, 23, 127, 212, 219, 222, 63, 98, 45, 102, 165, 88, 255, 220], celestia_header_hash: [120, 107, 54, 46, 182, 50, 89, 93, 115, 224, 125, 214, 72, 215, 109, 67, 90, 48, 217, 144, 215, 85, 206, 228, 192, 183, 123, 79, 244, 136, 195, 212] }

After:

> BlevmOutput { blob_commitment: [121, 70, 207, 82, 142, 221, 116, 94, 251, 37, 32, 18, 70, 230, 71, 213, 170, 202, 63, 181, 43, 240, 246, 6, 182, 149, 180, 171, 11, 211, 63, 76], header_hash: [133, 106, 134, 184, 20, 76, 104, 254, 40, 136, 41, 140, 238, 199, 193, 86, 163, 56, 170, 193, 61, 146, 213, 227, 194, 70, 12, 164, 151, 147, 237, 105], prev_header_hash: [187, 154, 187, 153, 78, 140, 25, 59, 84, 254, 152, 25, 224, 239, 83, 45, 145, 73, 226, 110, 100, 51, 95, 167, 27, 102, 84, 16, 217, 139, 202, 206], **height: 18884864, gas_used: 4266500**, beneficiary: [149, 34, 34, 144, 221, 114, 120, 170, 61, 221, 56, 156, 193, 225, 209, 101, 204, 75, 175, 229], state_root: [27, 56, 213, 58, 25, 68, 72, 76, 140, 126, 48, 23, 127, 212, 219, 222, 63, 98, 45, 102, 165, 88, 255, 220, 120, 107, 54, 46, 182, 50, 89, 93], celestia_header_hash: [115, 224, 125, 214, 72, 215, 109, 67, 90, 48, 217, 144, 215, 85, 206, 228, 192, 183, 123, 79, 244, 136, 195, 212, 76, 85, 47, 180, 146, 37, 100, 140] }

