### PR TITLE
docs: fix markdown links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,8 @@ lint:
 ## markdown-link-check: Check all markdown links.
 markdown-link-check:
 	@echo "--> Running markdown-link-check"
-	@find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
+# Skip the solidity-ibc-eureka directory because we don't want to fix their broken links.
+	@find . -name \*.md -not -path "./solidity-ibc-eureka/*" -print0 | xargs -0 -n1 markdown-link-check
 .PHONY: markdown-link-check
 
 ## fmt: Format files per linters golangci-lint and markdownlint.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo exists to showcase transferring tokens to and from a Cosmos SDK chain 
 
 ![mvp-zk-accounts](./docs/images/mvp-zk-accounts.png)
 
-For more information refer to the [architecture document](./ARCHITECTURE.md). Note that the design is subject to change.
+For more information refer to the [architecture](./docs/ARCHITECTURE.md). Note that the design is subject to change.
 
 ## Usage
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/207

## Testing

```
$ make lint
--> Running golangci-lint
--> Running markdownlint
--> Running hadolint
```