### PR TITLE
fix: create groth16 client with STF verifier key from EVM prover

### DIFF
--- a/provers/blevm/README.md
+++ b/provers/blevm/README.md
@@ -115,7 +115,6 @@ The `blevm-tools` binary can be used to re-create the serialized evm block that 
     ```
 
     The resulting blob is included in [Celestia block number 2988873](https://celenium.io/blob?commitment=eUbPUo7ddF77JSASRuZH1arKP7Ur8PYGtpW0qwvTP0w=&hash=AAAAAAAAAAAAAAAAAAAAAAAAAA8PDw8PDw8PDw8=&height=2988873).
-    
 
     The inclusion of this blob in Celestia will be verified by the `blevm` sp1 program before verifying the execution of the EVM block. This
     allows us to verify that the correct EVM block was included in the data square and simultaneously verify the correct execution of the EVM block.

--- a/testing/demo/pkg/setup/consts.go
+++ b/testing/demo/pkg/setup/consts.go
@@ -2,6 +2,11 @@ package main
 
 import "math/big"
 
+var (
+	ethChainId   = big.NewInt(80087)
+	merklePrefix = [][]byte{[]byte("ibc"), []byte("")}
+)
+
 const (
 	// groth16ClientID is for the Ethereum light client on the SimApp.
 	groth16ClientID = "08-groth16-0"
@@ -11,13 +16,14 @@ const (
 	ethPrivateKey = "0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a"
 	// relayer is the address registered on simapp
 	relayer = "cosmos1ltvzpwf3eg8e9s7wzleqdmw02lesrdex9jgt0q"
-	// simappRPC is the URI for the simapp node.
-	simappRPC = "http://localhost:5123"
-	// ethereumRPC is the URI for the ethereum node.
-	ethereumRPC = "http://localhost:8545"
 )
 
-var (
-	ethChainId   = big.NewInt(80087)
-	merklePrefix = [][]byte{[]byte("ibc"), []byte("")}
+// RPC endpoints
+const (
+	// ethereumRPC is the Reth RPC endpoint.
+	ethereumRPC = "http://localhost:8545/"
+	// evmProverRPC is the RPC endpoint for the EVM prover.
+	evmProverRPC = "localhost:50052"
+	// simappRPC is the URI for the simapp node.
+	simappRPC = "http://localhost:5123"
 )

--- a/testing/demo/pkg/setup/groth16.go
+++ b/testing/demo/pkg/setup/groth16.go
@@ -2,17 +2,21 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/celestiaorg/celestia-zkevm-ibc-demo/ibc/lightclients/groth16"
+	proverclient "github.com/celestiaorg/celestia-zkevm-ibc-demo/provers/client"
+	"github.com/celestiaorg/celestia-zkevm-ibc-demo/testing/demo/pkg/utils"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/celestiaorg/celestia-zkevm-ibc-demo/testing/demo/pkg/utils"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // CreateGroth16LightClient creates the Groth16 light client on simapp.
@@ -59,14 +63,18 @@ func createClientAndConsensusState() (*cdctypes.Any, *cdctypes.Any, error) {
 		return nil, nil, err
 	}
 
-	// TODO: Query the stateTransitionVerifierKey and stateMembershipVerifierKey from the EVM prover.
-	// Query the celestia prover info endpoint for the state transition verifier key
-	// conn, err := grpc.NewClient(evmProverRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	stateTransitionVerifierKey, err := getStateTransitionVerifierKey()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get state transition verifier key: %w", err)
+	}
+	fmt.Printf("Got state transition verifier key: %x\n", stateTransitionVerifierKey)
+
+	// TODO: Uncomment this code once the EVM prover info endpoint includes a state memberhsip verifier key.
+	// stateMembershipVerifierKey, err := getStateMembershipVerifierKey()
 	// if err != nil {
-	// 	return nil, nil, fmt.Errorf("failed to connect to prover: %w", err)
+	// 	return nil, nil, fmt.Errorf("failed to get state membership verifier key: %w", err)
 	// }
-	// defer conn.Close()
-	stateTransitionVerifierKey := []byte{}
+	// fmt.Printf("State state membership verifier key: %v\n", stateMembershipVerifierKey)
 	stateMembershipVerifierKey := []byte{}
 
 	// TODO: Query the codeCommitment from the EVM rollup.
@@ -132,4 +140,44 @@ func getGenesisAndLatestBlock(ethClient *ethclient.Client) (*ethtypes.Block, *et
 	}
 
 	return genesisBlock, latestBlock, nil
+}
+
+func getStateTransitionVerifierKey() ([]byte, error) {
+	info, err := getEvmProverInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get evm prover info %w", err)
+	}
+
+	decoded, err := hex.DecodeString(strings.TrimPrefix(info.StateTransitionVerifierKey, "0x"))
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to decode state transition verifier key %w", err)
+	}
+	return decoded, nil
+}
+
+func getStateMembershipVerifierKey() ([]byte, error) {
+	info, err := getEvmProverInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get evm prover info %w", err)
+	}
+
+	decoded, err := hex.DecodeString(strings.TrimPrefix(info.StateMembershipVerifierKey, "0x"))
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to decode state membership verifier key %w", err)
+	}
+	return decoded, nil
+}
+
+func getEvmProverInfo() (*proverclient.InfoResponse, error) {
+	conn, err := grpc.NewClient(evmProverRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to evm prover: %w", err)
+	}
+	defer conn.Close()
+	proverClient := proverclient.NewProverClient(conn)
+	info, err := proverClient.Info(context.Background(), &proverclient.InfoRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get evm prover info %w", err)
+	}
+	return info, nil
 }

--- a/testing/demo/pkg/setup/groth16.go
+++ b/testing/demo/pkg/setup/groth16.go
@@ -155,18 +155,19 @@ func getStateTransitionVerifierKey() ([]byte, error) {
 	return decoded, nil
 }
 
-func getStateMembershipVerifierKey() ([]byte, error) {
-	info, err := getEvmProverInfo()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get evm prover info %w", err)
-	}
+// TODO: Uncomment this function once the EVM prover info endpoint includes a state membership verifier key.
+// func getStateMembershipVerifierKey() ([]byte, error) {
+// 	info, err := getEvmProverInfo()
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to get evm prover info %w", err)
+// 	}
 
-	decoded, err := hex.DecodeString(strings.TrimPrefix(info.StateMembershipVerifierKey, "0x"))
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to decode state membership verifier key %w", err)
-	}
-	return decoded, nil
-}
+// 	decoded, err := hex.DecodeString(strings.TrimPrefix(info.StateMembershipVerifierKey, "0x"))
+// 	if err != nil {
+// 		return []byte{}, fmt.Errorf("failed to decode state membership verifier key %w", err)
+// 	}
+// 	return decoded, nil
+// }
 
 func getEvmProverInfo() (*proverclient.InfoResponse, error) {
 	conn, err := grpc.NewClient(evmProverRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/testing/demo/pkg/transfer/consts.go
+++ b/testing/demo/pkg/transfer/consts.go
@@ -1,25 +1,41 @@
 package main
 
+// Tokens
 const (
 	// denom is the denomination of the token on SimApp.
 	denom = "stake"
+)
+
+// Addresses
+const (
 	// sender is an address on SimApp that will send funds via the MsgTransfer.
 	sender = "cosmos1ltvzpwf3eg8e9s7wzleqdmw02lesrdex9jgt0q"
 	// receiver is an address on the EVM chain that will receive funds via the MsgTransfer.
 	receiver = "0x7f39c581f595b53c5cb19b5a6e5b8f3a0b1f2f6e"
-	// ethPrivateKey is the private key for ethereumAddress.
-	ethPrivateKey = "0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a"
+)
 
+// Client IDs
+const (
 	// tendermintClientID is for the SP1 Tendermint light client on the EVM roll-up.
 	tendermintClientID = "07-tendermint-0"
 	// groth16ClientID is for the Ethereum light client on the SimApp.
 	groth16ClientID = "08-groth16-0"
+)
 
+// RPC endpoints
+const (
 	// ethereumRPC is the Reth RPC endpoint.
 	ethereumRPC = "http://localhost:8545/"
 	// celestiaProverRPC is the RPC endpoint for the Celestia prover.
 	celestiaProverRPC = "localhost:50051"
+	// evmProverRPC is the RPC endpoint for the EVM prover.
+	evmProverRPC = "localhost:50052"
 )
 
-// ethereumAddress is an address on the EVM chain.
-// _ethereumAddress = "0xaF9053bB6c4346381C77C2FeD279B17ABAfCDf4d"
+// Keys
+const (
+	// ethPrivateKey is the private key for ethereumAddress.
+	ethPrivateKey = "0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a"
+	// ethereumAddress is an address on the EVM chain.
+	// _ethereumAddress = "0xaF9053bB6c4346381C77C2FeD279B17ABAfCDf4d"
+)

--- a/testing/demo/pkg/transfer/consts.go
+++ b/testing/demo/pkg/transfer/consts.go
@@ -28,8 +28,6 @@ const (
 	ethereumRPC = "http://localhost:8545/"
 	// celestiaProverRPC is the RPC endpoint for the Celestia prover.
 	celestiaProverRPC = "localhost:50051"
-	// evmProverRPC is the RPC endpoint for the EVM prover.
-	evmProverRPC = "localhost:50052"
 )
 
 // Keys

--- a/testing/demo/pkg/transfer/relay.go
+++ b/testing/demo/pkg/transfer/relay.go
@@ -22,8 +22,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// relayByTx implements the logic of an IBC relayer.
-// It processes source tx, extracts IBC events, generates proofs,
+// relayByTx implements the logic of an IBC relayer for a MsgTransfer from SimApp to EVM roll-up.
+// It processes the sourceTxHash of a MsgTransfer, extracts the IBC events, generates proofs,
 // and creates an Ethereum transaction to submit to the ICS26Router contract.
 func relayByTx(sourceTxHash string, targetClientID string) error {
 	fmt.Printf("Relaying IBC transaction %s to client %s...\n", sourceTxHash, targetClientID)

--- a/testing/demo/pkg/transfer/relay.go
+++ b/testing/demo/pkg/transfer/relay.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -22,16 +21,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
-
-// FungibleTokenPacketData represents the ICS20 token transfer data structure
-// It should match IICS20TransferMsgs.FungibleTokenPacketData in the Solidity contract
-type FungibleTokenPacketData struct {
-	Denom    string
-	Amount   *big.Int
-	Sender   string
-	Receiver string
-	Memo     string
-}
 
 // relayByTx implements the logic of an IBC relayer.
 // It processes source tx, extracts IBC events, generates proofs,
@@ -128,9 +117,7 @@ func getCelestiaProverResponse(event SendPacketEvent) (*proverclient.ProveStateM
 }
 
 func getMsgRecvPacket(event SendPacketEvent, resp *proverclient.ProveStateMembershipResponse) (msgRecvPacket ics26router.IICS26RouterMsgsMsgRecvPacket, err error) {
-	// HACKHACK: ideally we would decode the encodedPacketHex and convert the payload into a FungibleTokenPacketData but this doesn't work.
-	// rawPayload, err := hex.DecodeString(event.EncodedPacketHex)
-	// Instead, we just get the ABI encoded fungible token packet data that was used to create the packet.
+	// TODO: instead of using getPayloadValue, we should decode the encodedPacketHex and convert the payload into a FungibleTokenPacketData. This isn't trivial to do because there is no utility method to decode the encodedPacketHex and ABI encode it.
 	value, err := getPayloadValue()
 	if err != nil {
 		return ics26router.IICS26RouterMsgsMsgRecvPacket{}, fmt.Errorf("failed to get payload value: %w", err)


### PR DESCRIPTION
Addresses 3 FLUPs from @cmwaters review on https://github.com/celestiaorg/celestia-zkevm-ibc-demo/pull/186:
1. Create Groth16 client with STF verifier key from EVM prover. The EVM prover doesn't return a membership verifier key yet.
2. Clarify a comment for relayByTx
3. Remove `FungibleTokenPacketData` because it's not needed until we resolve a TODO

## Testing

```shell
make stop && make demo

Got state transition verifier key: 00d03e583079d6e27e3904d12548a44e7914721bb977e2a81faafa747092b7de
```

and then manually verified that matches the EVM prover

```
$ grpcurl -plaintext localhost:50052 celestia.prover.v1.Prover/Info
{
  "stateTransitionVerifierKey": "0x00d03e583079d6e27e3904d12548a44e7914721bb977e2a81faafa747092b7de"
}
```