### PR TITLE
docs: de-duplicate README and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For more information refer to the [architecture](./docs/ARCHITECTURE.md). Note t
 1. Run the demo
 
     ```shell
+    # This runs make start, setup, and transfer
     make demo
     ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# ZK-EVM X Celestia Token Transfer Demo
+# ZK EVM IBC demo
 
 > [!WARNING]
 > This repository is a work in progress and under active development.
 
-This repo exists to showcase transferring tokens to and from a Cosmos SDK chain (representing Celestia) and a ZK proveable EVM using the [IBC-Eureka solidity contracts](https://github.com/cosmos/solidity-ibc-eureka/blob/main/README.md). The diagram below is meant to detail the components involved and, at a high level, how they interact with one another.
+This repo exists to showcase transferring tokens between SimApp (a Cosmos SDK chain representing Celestia) and a ZK proveable EVM via [IBC V2](https://github.com/cosmos/ibc/blob/main/spec/IBC_V2/README.md) (formerly known as IBC Eureka) and the IBC V2 [solidity contracts](https://github.com/cosmos/solidity-ibc-eureka/blob/main/README.md). The diagram below is meant to detail the components involved and, at a high level, how they interact with one another.
 
 ![mvp-zk-accounts](./docs/images/mvp-zk-accounts.png)
 
@@ -73,75 +73,13 @@ For more information refer to the [architecture](./docs/ARCHITECTURE.md). Note t
 1. Run the demo
 
     ```shell
-    # Start the Docker containers
-    make start
-    # Set up IBC light clients on SimApp and the EVM roll-up.
-    make setup
-    # Transfer tokens from SimApp to the EVM roll-up.
-    make transfer
-    # Relay the token transfer
-    make relay
-    # When you're done, stop the Docker containers
-    make stop
+    make demo
     ```
 
-## A Breakdown of an IBC Transfer
+## Architecture
 
-This section takes the diagram from above and breaks down each step during `make transfer` to help aid your understanding.
-
-![mvp-zk-accounts](./docs/images/mvp-zk-accounts-step-1.png)
-
-1a -> The user submits a transfer message. This is a `ICS20LibFungibleTokenPacketData` wrapped in a `SendPacket` message. As well as who it's sending the tokens to and how much it also specifies where this packet is going to and lets the eventual receiver know where the packet came from.
-
-1b -> The SimApp chain (mimicking Celestia) executes the transaction, checking the user's balance and then moving the funds to a locked acount. It stores a commitment to this execution in state. This is kind of like a verifiable receipt.
-
-![mvp-zk-accounts](./docs/images/mvp-zk-accounts-step-2.png)
-
-2a -> Now the relayer kicks in. It listens to events that SimApp has emitted that there are pending packets ready to be sent to other chains. It queries the chain for the receipt based on a predetermined location.
-
-2b -> The relayer needs to prove to the EVM rollup that SimApp has actually successfully executed the first part of the transfer: locking up the tokens. Proving this requires two steps: First the relayer queries a state transition proof from the prover process. This will prove the latest state root from the last trusted state root stored in the state of the ICS07 Tendermint smart contract on the EVM. Now the EVM has an up to date record of SimApp's current state (which includes the receipt). Second, the relayer asks the prover for a proof that the receipt is a merkle leaf of the state root i.e. it's part of state
-
-2c -> The prover has a zk circuit for generating both proofs. One takes tendermint headers and uses the `SkippingVerification` algorithm to assert the latest header. The other takes IAVL merkle proofs and proves some leaf key as part of the root. These are both STARK proofs which can be processed by the smart contracts on the EVM.
-
-2d -> The last step of the relayer is to combine these proofs and packets and submit a `MsgUpdateClient` and `MsgRecvPacket` to the EVM rollup.
-
-![mvp-zk-accounts](./docs/images/mvp-zk-accounts-step-3.png)
-
-Step 3 mirrors step 2 in many ways but now in the opposite direction
-
-3a -> The EVM executes both messages. It verifies the STARK proofs and updates it's local record of SimApp's state. It then uses the updated state to verify that the receipt that the packet refers is indeed present in SimApp's state. Once all the verification checks are passed. It mints the tokens and adds them to the account of the recipient as specified in the packet. The rollup then writes it's own respective receipt that it processed the corresponding message.
-
-3b -> Similarly, the relayer listens for events emitted from the EVM rollup for any packets awaiting to be sent back. Upon receiving the packet to be returned, an acknowledgement of the transfer to be sent back to SimApp, it talks to the prover service to prepare the relevant proofs. While they are of different state machines and different state trees, the requests are universal: a proof of the state transition and a proof of membership. The EVM Prover Service here futher compresses the STARK proofs into groth16 proofs for SimApp's groth16 IBC Client.
-
-3c -> The relayer then sends a `MsgUpdateClient` with the state transition proof to update SimApp's record of the Rollup's state after the point that it processed the transfer packet and wrote the receipt. The relayer also sends a `MsgAcknowledgement` which contains the membership proof of the commitment, a.k.a. the receipt alongside the details of the receipt i.e. for what transfer message are we acknowledging.
-
-3d -> SimApp processes these two messages. It validates the proofs and if everything is in order, it removes the transfer receipt and keeps one final receipt of the acknowledgement (to prevent a later timeout message).
-
-In the case that the EVM decided these messages were not valid it would not write the acknowledgement receipt. The relayer, tracking the time when the transfer message was sent would submit a `MsgTimeout` instead of the acknowledgement with an absence proof. This is a proof that no acknowledgement was written where the predermined path says it should be written. When SimApp receives this timeout and the corresponding absence proof, it reverses the transfer, releaseing the locked funds and returning them to the sender. This process is atomic - funds can not be unlocked if they are minted on the other chain.
-
-If someone were to send tokens from the EVM rollup back to SimApp, the source chain of those tokens, the process would be very similar, however the actions wouldn't be to lock and mint but rather the EVM rollup would burn tokens and SimApp would unlock them.
+See [ARCHITECTURE.md](./docs/ARCHITECTURE.md) for more information.
 
 ## Contributing
 
-### Proto Generation
-
-This repo uses protobuf to define the interfaces between several services. To help with this, this
-repo relies on [buf](https://buf.build). If you modify the protos you can regenerate them using:
-
-```shell
-make proto-gen
-```
-
-### Helpful commands
-
-```shell
-# See the running containers
-docker ps
-
-# You can view the logs from a running container via Docker UI or:
-docker logs beacond
-docker logs celestia-network-bridge
-docker logs celestia-network-validator
-docker logs simapp-validator
-docker logs reth
-```
+See [CONTRIBUTING.md](./docs/CONTRIBUTING.md) for more information.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,31 @@
 
 // TODO: The STARK proofs in this diagram are actually Groth16 proofs.
 
+```mermaid
+architecture-beta
+    group evmrollup[EVM Rollup]
+    service beaconkit[BeaconKit] in evmrollup
+    group reth[Reth] in evmrollup
+    service tendermintlightclient[Tendermint light client] in reth
+
+
+    group simapp[SimApp]
+    service groth16lightclient[Groth16 light client] in simapp
+
+    group celestia[Celestia]
+    service celestiavalidator[Celestia Validator] in celestia
+    service celestiabridge[Celestia Bridge] in celestia
+
+    service evmprover[EVM Prover]
+    service celestiaprover[Celestia Prover]
+
+    service relayer[Relayer]
+
+    beaconkit{group}:B -- T:celestiavalidator{group}
+    evmprover:B -- T:beaconkit{group}
+    celestiaprover:B -- T:groth16lightclient{group}
+```
+
 ## IBC Transfer flow
 
 This section takes the diagram from above and breaks down each step to help aid your understanding.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture
 
-// TODO: remove STARK proofs from this diagram
-
 ![mvp-zk-accounts](./images/mvp-zk-accounts.png)
+
+// TODO: The STARK proofs in this diagram are actually Groth16 proofs.
 
 ## IBC Transfer flow
 
@@ -39,19 +39,17 @@ sequenceDiagram
     EVM->>EVM: Store receipt
 ```
 
-1. The user submits a transfer message. This is a `ICS20LibFungibleTokenPacketData` wrapped in a `SendPacket` message. As well as who it's sending the tokens to and how much it also specifies where this packet is going to and lets the eventual receiver know where the packet came from.
-1. The SimApp chain (mimicking Celestia) executes the transaction, checking the user's balance and then moving the funds to a locked acount. It stores a commitment to this execution in state. This is kind of like a verifiable receipt.
+1. The user submits a transfer message. This is a `MsgSendPacket` with an `ICS20LibFungibleTokenPacketData`. As well as who it's sending the tokens to and how much it also specifies where this packet is going to and lets the eventual receiver know where the packet came from.
+1. The SimApp chain (mimicking Celestia) executes the transaction. It checks the user's balance and then moves the funds to a locked acount. It stores a commitment to this execution in state. This is kind of like a verifiable receipt.
 1. Now the relayer kicks in. It listens to events that SimApp has emitted that there are pending packets ready to be sent to other chains. It queries the chain for the receipt based on a predetermined location.
 1. The relayer needs to prove to the EVM rollup that SimApp has actually successfully executed the first part of the transfer: locking up the tokens. Proving this requires two steps: First the relayer queries a state transition proof from the celestia-prover. This will prove the latest state root from the last trusted state root stored in the state of the ICS07 Tendermint smart contract on the EVM. Now the EVM has an up to date record of SimApp's current state (which includes the receipt). Second, the relayer asks the celestia-prover for a proof that the receipt is a merkle leaf of the state root.
 1. The celestia-prover has a zk circuit for generating both proofs. One takes tendermint headers and uses the `SkippingVerification` algorithm to assert the latest header. The other takes IAVL merkle proofs and proves some leaf key as part of the root. These are both SP1 proofs which can be processed by the smart contracts on the EVM.
 1. The last step of the relayer is to combine these proofs and packets and submit a `MsgUpdateClient` and `MsgRecvPacket` to the EVM rollup.
+1. The EVM executes both messages. It verifies the SP1 proofs and updates it's local record of SimApp's state. It then uses the updated state to verify that the receipt that the packet refers is indeed present in SimApp's state. Once all the verification checks are passed, it mints the tokens and adds them to the account of the recipient as specified in the packet. The rollup then writes it's own respective receipt that it processed the corresponding message.
 
-## To-do
+The remaining steps mirror the previous steps but now in the opposite direction to acknowledge the transfer success back on SimApp. Note these steps haven't been implemented.
 
-The remaining steps mirror the previous steps but now in the opposite direction
-
-1. The EVM executes both messages. It verifies the STARK proofs and updates it's local record of SimApp's state. It then uses the updated state to verify that the receipt that the packet refers is indeed present in SimApp's state. Once all the verification checks are passed. It mints the tokens and adds them to the account of the recipient as specified in the packet. The rollup then writes it's own respective receipt that it processed the corresponding message.
-1. Similarly, the relayer listens for events emitted from the EVM rollup for any packets awaiting to be sent back. Upon receiving the packet to be returned, an acknowledgement of the transfer to be sent back to SimApp, it talks to the prover service to prepare the relevant proofs. While they are of different state machines and different state trees, the requests are universal: a proof of the state transition and a proof of membership. The EVM Prover Service here futher compresses the STARK proofs into groth16 proofs for SimApp's groth16 IBC Client.
+1. Similarly, the relayer listens for events emitted from the EVM rollup for any packets awaiting to be sent back. Upon receiving the packet to be returned, an acknowledgement of the transfer to be sent back to SimApp, it talks to the evm-prover to prepare the relevant proofs. While they are of different state machines and different state trees, the requests are universal: a proof of the state transition and a proof of membership. The evm-prover generates Groth16 proofs for SimApp's groth16 IBC Client.
 1. The relayer then sends a `MsgUpdateClient` with the state transition proof to update SimApp's record of the Rollup's state after the point that it processed the transfer packet and wrote the receipt. The relayer also sends a `MsgAcknowledgement` which contains the membership proof of the commitment, a.k.a. the receipt alongside the details of the receipt i.e. for what transfer message are we acknowledging.
 1. SimApp processes these two messages. It validates the proofs and if everything is in order, it removes the transfer receipt and keeps one final receipt of the acknowledgement (to prevent a later timeout message).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,38 +1,59 @@
 # Architecture
 
+// TODO: remove STARK proofs from this diagram
+
 ![mvp-zk-accounts](./images/mvp-zk-accounts.png)
 
-## A Breakdown of an IBC Transfer
+## IBC Transfer flow
 
-This section takes the diagram from above and breaks down each step during `make transfer` to help aid your understanding.
+This section takes the diagram from above and breaks down each step to help aid your understanding.
 
-![mvp-zk-accounts](./images/mvp-zk-accounts-step-1.png)
+```mermaid
+sequenceDiagram
+    participant User
+    participant SimApp
+    participant Relayer
+    participant CelestiaProver
+    participant EVM
 
-1a -> The user submits a transfer message. This is a `ICS20LibFungibleTokenPacketData` wrapped in a `SendPacket` message. As well as who it's sending the tokens to and how much it also specifies where this packet is going to and lets the eventual receiver know where the packet came from.
+    %% Step 1: Initial Transfer
+    User->>SimApp: Submit MsgTransfer (with an ICS20LibFungibleTokenPacketData)
+    SimApp->>SimApp: Execute transaction
+    Note over SimApp: Check balance & lock funds
+    SimApp->>SimApp: Store commitment in state
 
-1b -> The SimApp chain (mimicking Celestia) executes the transaction, checking the user's balance and then moving the funds to a locked acount. It stores a commitment to this execution in state. This is kind of like a verifiable receipt.
+    %% State Transition Proof
+    SimApp-->>Relayer: Emit SendPacket events
+    Relayer->>CelestiaProver: Query state transition proof
+    CelestiaProver-->>Relayer: Return SP1 state transition proof
+    Relayer->>EVM: Submit MsgUpdateClient with state transition proof
+    EVM->>EVM: Verify SP1 proof
+    EVM->>EVM: Update Tendermint light client
 
-![mvp-zk-accounts](./images/mvp-zk-accounts-step-2.png)
+    %% State Membership Proof
+    Relayer->>CelestiaProver: Query membership proof
+    CelestiaProver-->>Relayer: Return SP1 membership proof
+    Relayer->>EVM: Submit MsgRecvPacket with membership proof
+    EVM->>EVM: Verify receipt in SimApp state
+    EVM->>EVM: Mint tokens to recipient
+    EVM->>EVM: Store receipt
+```
 
-2a -> Now the relayer kicks in. It listens to events that SimApp has emitted that there are pending packets ready to be sent to other chains. It queries the chain for the receipt based on a predetermined location.
+1. The user submits a transfer message. This is a `ICS20LibFungibleTokenPacketData` wrapped in a `SendPacket` message. As well as who it's sending the tokens to and how much it also specifies where this packet is going to and lets the eventual receiver know where the packet came from.
+1. The SimApp chain (mimicking Celestia) executes the transaction, checking the user's balance and then moving the funds to a locked acount. It stores a commitment to this execution in state. This is kind of like a verifiable receipt.
+1. Now the relayer kicks in. It listens to events that SimApp has emitted that there are pending packets ready to be sent to other chains. It queries the chain for the receipt based on a predetermined location.
+1. The relayer needs to prove to the EVM rollup that SimApp has actually successfully executed the first part of the transfer: locking up the tokens. Proving this requires two steps: First the relayer queries a state transition proof from the celestia-prover. This will prove the latest state root from the last trusted state root stored in the state of the ICS07 Tendermint smart contract on the EVM. Now the EVM has an up to date record of SimApp's current state (which includes the receipt). Second, the relayer asks the celestia-prover for a proof that the receipt is a merkle leaf of the state root.
+1. The celestia-prover has a zk circuit for generating both proofs. One takes tendermint headers and uses the `SkippingVerification` algorithm to assert the latest header. The other takes IAVL merkle proofs and proves some leaf key as part of the root. These are both SP1 proofs which can be processed by the smart contracts on the EVM.
+1. The last step of the relayer is to combine these proofs and packets and submit a `MsgUpdateClient` and `MsgRecvPacket` to the EVM rollup.
 
-2b -> The relayer needs to prove to the EVM rollup that SimApp has actually successfully executed the first part of the transfer: locking up the tokens. Proving this requires two steps: First the relayer queries a state transition proof from the prover process. This will prove the latest state root from the last trusted state root stored in the state of the ICS07 Tendermint smart contract on the EVM. Now the EVM has an up to date record of SimApp's current state (which includes the receipt). Second, the relayer asks the prover for a proof that the receipt is a merkle leaf of the state root i.e. it's part of state
+## To-do
 
-2c -> The prover has a zk circuit for generating both proofs. One takes tendermint headers and uses the `SkippingVerification` algorithm to assert the latest header. The other takes IAVL merkle proofs and proves some leaf key as part of the root. These are both STARK proofs which can be processed by the smart contracts on the EVM.
+The remaining steps mirror the previous steps but now in the opposite direction
 
-2d -> The last step of the relayer is to combine these proofs and packets and submit a `MsgUpdateClient` and `MsgRecvPacket` to the EVM rollup.
-
-![mvp-zk-accounts](./images/mvp-zk-accounts-step-3.png)
-
-Step 3 mirrors step 2 in many ways but now in the opposite direction
-
-3a -> The EVM executes both messages. It verifies the STARK proofs and updates it's local record of SimApp's state. It then uses the updated state to verify that the receipt that the packet refers is indeed present in SimApp's state. Once all the verification checks are passed. It mints the tokens and adds them to the account of the recipient as specified in the packet. The rollup then writes it's own respective receipt that it processed the corresponding message.
-
-3b -> Similarly, the relayer listens for events emitted from the EVM rollup for any packets awaiting to be sent back. Upon receiving the packet to be returned, an acknowledgement of the transfer to be sent back to SimApp, it talks to the prover service to prepare the relevant proofs. While they are of different state machines and different state trees, the requests are universal: a proof of the state transition and a proof of membership. The EVM Prover Service here futher compresses the STARK proofs into groth16 proofs for SimApp's groth16 IBC Client.
-
-3c -> The relayer then sends a `MsgUpdateClient` with the state transition proof to update SimApp's record of the Rollup's state after the point that it processed the transfer packet and wrote the receipt. The relayer also sends a `MsgAcknowledgement` which contains the membership proof of the commitment, a.k.a. the receipt alongside the details of the receipt i.e. for what transfer message are we acknowledging.
-
-3d -> SimApp processes these two messages. It validates the proofs and if everything is in order, it removes the transfer receipt and keeps one final receipt of the acknowledgement (to prevent a later timeout message).
+1. The EVM executes both messages. It verifies the STARK proofs and updates it's local record of SimApp's state. It then uses the updated state to verify that the receipt that the packet refers is indeed present in SimApp's state. Once all the verification checks are passed. It mints the tokens and adds them to the account of the recipient as specified in the packet. The rollup then writes it's own respective receipt that it processed the corresponding message.
+1. Similarly, the relayer listens for events emitted from the EVM rollup for any packets awaiting to be sent back. Upon receiving the packet to be returned, an acknowledgement of the transfer to be sent back to SimApp, it talks to the prover service to prepare the relevant proofs. While they are of different state machines and different state trees, the requests are universal: a proof of the state transition and a proof of membership. The EVM Prover Service here futher compresses the STARK proofs into groth16 proofs for SimApp's groth16 IBC Client.
+1. The relayer then sends a `MsgUpdateClient` with the state transition proof to update SimApp's record of the Rollup's state after the point that it processed the transfer packet and wrote the receipt. The relayer also sends a `MsgAcknowledgement` which contains the membership proof of the commitment, a.k.a. the receipt alongside the details of the receipt i.e. for what transfer message are we acknowledging.
+1. SimApp processes these two messages. It validates the proofs and if everything is in order, it removes the transfer receipt and keeps one final receipt of the acknowledgement (to prevent a later timeout message).
 
 In the case that the EVM decided these messages were not valid it would not write the acknowledgement receipt. The relayer, tracking the time when the transfer message was sent would submit a `MsgTimeout` instead of the acknowledgement with an absence proof. This is a proof that no acknowledgement was written where the predermined path says it should be written. When SimApp receives this timeout and the corresponding absence proof, it reverses the transfer, releaseing the locked funds and returning them to the sender. This process is atomic - funds can not be unlocked if they are minted on the other chain.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,31 +4,6 @@
 
 // TODO: The STARK proofs in this diagram are actually Groth16 proofs.
 
-```mermaid
-architecture-beta
-    group evmrollup[EVM Rollup]
-    service beaconkit[BeaconKit] in evmrollup
-    group reth[Reth] in evmrollup
-    service tendermintlightclient[Tendermint light client] in reth
-
-
-    group simapp[SimApp]
-    service groth16lightclient[Groth16 light client] in simapp
-
-    group celestia[Celestia]
-    service celestiavalidator[Celestia Validator] in celestia
-    service celestiabridge[Celestia Bridge] in celestia
-
-    service evmprover[EVM Prover]
-    service celestiaprover[Celestia Prover]
-
-    service relayer[Relayer]
-
-    beaconkit{group}:B -- T:celestiavalidator{group}
-    evmprover:B -- T:beaconkit{group}
-    celestiaprover:B -- T:groth16lightclient{group}
-```
-
 ## IBC Transfer flow
 
 This section takes the diagram from above and breaks down each step to help aid your understanding.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Proto Generation
+
+This repo uses protobuf to define the interfaces between several services. To help with this, this
+repo relies on [buf](https://buf.build). If you modify the protos you can regenerate them using:
+
+```shell
+make proto-gen
+```
+
+## Helpful commands
+
+```shell
+# See the running containers
+docker ps
+
+# You can view the logs from a running container via Docker UI or:
+docker logs beacond
+docker logs celestia-network-bridge
+docker logs celestia-network-validator
+docker logs simapp-validator
+docker logs reth
+```


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/170 by removing the old architecture doc and moving the more up to date README contents there. Then updated some of the steps and added a sequence diagram.