### PR TITLE
fix: rust-analyzer not indexing blevm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "rust-analyzer.linkedProjects": ["./provers/blevm/Cargo.toml"]
+  "rust-analyzer.linkedProjects": ["./provers/blevm/Cargo.toml", "Cargo.toml"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.linkedProjects": ["./provers/blevm/Cargo.toml"]
+}

--- a/provers/blevm/Cargo.toml
+++ b/provers/blevm/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["blevm", "script", "blevm-aggregator", "common"]
+members = ["blevm", "script", "blevm-aggregator", "blevm-prover", "common"]
 resolver = "2"
 edition = "2021"
 

--- a/provers/blevm/blevm-prover/src/lib.rs
+++ b/provers/blevm/blevm-prover/src/lib.rs
@@ -212,7 +212,6 @@ impl BlockProver {
         let (pk, vk) = client.setup(self.prover_config.elf_bytes);
         let stdin = self.get_stdin(input).await?;
         let proof = client.prove(&pk, &stdin).compressed().run()?;
-        println!("proof 1 {:?}", proof);
         Ok((proof, vk))
     }
 

--- a/provers/blevm/blevm-prover/src/lib.rs
+++ b/provers/blevm/blevm-prover/src/lib.rs
@@ -212,6 +212,7 @@ impl BlockProver {
         let (pk, vk) = client.setup(self.prover_config.elf_bytes);
         let stdin = self.get_stdin(input).await?;
         let proof = client.prove(&pk, &stdin).compressed().run()?;
+        println!("proof 1 {:?}", proof);
         Ok((proof, vk))
     }
 


### PR DESCRIPTION
## Overview

Temporary fix before we flatten our workspace structure. ref: #116 
