### PR TITLE
refactor: stop relying on .env file in solidity-ibc-eureka

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ For more information refer to the [architecture](./docs/ARCHITECTURE.md). Note t
 
 ## Usage
 
+### Preamble
+
+SP1 supports generating proofs in mock mode or network mode. By default, mock mode is used which is faster for testing and development purposes. Network mode is used for production purposes to generate real proofs. To use network mode, modify your `.env` file:
+
+```env
+SP1_PROVER=network
+NETWORK_PRIVATE_KEY="PRIVATE_KEY" to the SP1 prover network private key from Celestia 1Password
+```
+
 ### Prerequisites
 
 1. Install [Docker](https://docs.docker.com/get-docker/)
@@ -30,38 +39,10 @@ For more information refer to the [architecture](./docs/ARCHITECTURE.md). Note t
     git submodule update
     ```
 
-1. Create and populate the `.env` file in this repo
+1. Create the `.env` file in this repo
 
     ```shell
     cp .env.example .env
-    # Modify the .env file:
-    # Set SP1_PROVER=network
-    # Set NETWORK_PRIVATE_KEY="PRIVATE_KEY" to the SP1 prover network private key from Celestia 1Password
-    ```
-
-1. Create and populate the `.env` file in solidity-ibc-eureka
-
-    ```shell
-    cd solidity-ibc-eureka
-    cp .env.example .env
-    # Modify the .env file:
-    # Set VERIFIER=""
-    ```
-
-1. Modify the `docker-compose.yml` file and set `NETWORK_PRIVATE_KEY="PRIVATE_KEY"` to the SP1 prover network private key from Celestia 1Password.
-
-    ```diff
-    celestia-prover:
-        image: ghcr.io/celestiaorg/celestia-zkevm-ibc-demo/celestia-prover:latest
-        container_name: celestia-prover
-        environment:
-        # TENDERMINT_RPC_URL should be the SimApp which is acting as a substitute
-        # for Celestia (with IBC Eurekea enabled).
-        - TENDERMINT_RPC_URL=http://simapp-validator:26657
-        - RPC_URL=http://reth:8545
-        - CELESTIA_PROTO_DESCRIPTOR_PATH=proto_descriptor.bin
-        - SP1_PROVER=network
-    +   - NETWORK_PRIVATE_KEY=PRIVATE_KEY
     ```
 
 1. Install contract dependencies and the SP1 Tendermint light client operator binary from solidity-ibc-eureka.

--- a/testing/demo/pkg/setup/tendermint.go
+++ b/testing/demo/pkg/setup/tendermint.go
@@ -53,11 +53,19 @@ func deployEurekaContracts() error {
 	prover := os.Getenv("SP1_PROVER")
 	fmt.Printf("SP1_PROVER: %s\n", prover)
 
+	faucetAddress := os.Getenv("E2E_FAUCET_ADDRESS")
+	fmt.Printf("E2E_FAUCET_ADDRESS: %s\n", faucetAddress)
+
+	ethPrivateKey := os.Getenv("PRIVATE_KEY")
+	fmt.Printf("PRIVATE_KEY: %s\n", ethPrivateKey)
+
 	cmd := exec.Command("forge", "script", "E2ETestDeploy.s.sol:E2ETestDeploy", "--rpc-url", "http://localhost:8545", "--private-key", "0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a", "--broadcast")
-	cmd.Env = append(cmd.Env, "PRIVATE_KEY=0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a")
 	if prover == "mock" {
 		cmd.Env = append(cmd.Env, "VERIFIER=mock")
 	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("E2E_FAUCET_ADDRESS=%v", faucetAddress))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PRIVATE_KEY=%v", ethPrivateKey))
+
 	cmd.Dir = "./solidity-ibc-eureka/scripts"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/240

Previously it was a hack that `make setup` relied on environment variables set by the `.env` file in solidity-ibc-eureka. This PR removes the need for that file.

## Testing

```
cd solidity-ibc-eureka
mv .env .env.backup
```

```
make demo
```

still works