### PR TITLE
fix(indexer): add waitgroup outside gr

### DIFF
--- a/indexer/main.go
+++ b/indexer/main.go
@@ -211,8 +211,6 @@ func decodeEthBlockNumber(data []byte) (uint64, error) {
 
 // startIndexer starts the indexing service that listens for new Celestia blocks and extracts Ethereum block numbers
 func startIndexer(ctx context.Context, config Config) {
-	// Add to wait group before any possible returns
-	wg.Add(1)
 	defer wg.Done()
 
 	nsBytes, err := hex.DecodeString(config.CelestiaNamespace)
@@ -385,8 +383,6 @@ func processHeight(ctx context.Context, c *client.Client, namespace share.Namesp
 
 // startAPI starts the HTTP API server
 func startAPI(config Config) {
-	// Add to wait group before any possible returns
-	wg.Add(1)
 	defer wg.Done()
 
 	router := mux.NewRouter()
@@ -513,10 +509,12 @@ func main() {
 	}()
 
 	// Start the API service
+	wg.Add(1)
 	go startAPI(config)
 	log.Println("API service started")
 
 	// Start the indexer service
+	wg.Add(1)
 	go startIndexer(ctx, config)
 	log.Println("Indexer service started")
 


### PR DESCRIPTION
## Overview

Sometimes the indexer runs into a loop:

> 2025-04-18 11:25:31 2025/04/18 15:25:31 API service started
> 2025-04-18 11:25:31 2025/04/18 15:25:31 Indexer service started
> 2025-04-18 11:25:31 2025/04/18 15:25:31 All services started successfully, running...
> 2025-04-18 11:25:31 2025/04/18 15:25:31 All services have shut down. Exiting.

This might happen if the goroutine fires _after_ `wg.Wait` due to late scheduling. Instead, we move the `wg.Add` outside of the goroutines.