### PR TITLE
docs: add architecture doc for evm-prover

### DIFF
--- a/provers/evm-prover/ARCHITECTURE.md
+++ b/provers/evm-prover/ARCHITECTURE.md
@@ -1,174 +1,6 @@
 # EVM Prover
 
-The EVM Prover implements the Prover service for EVM rollups, creating zero-knowledge proofs for state membership and state transitions. It uses SP1 programs (`blevm` and `blevm-aggregator`) to generate ZK proofs of data inclusion in Celestia and EVM execution using the Rollup State Prover (RSP).
-
-## IBC Transfer Architecture
-
-The EVM Prover is a key component in the IBC transfer architecture, enabling secure asset transfers between Celestia and EVM rollups.
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant SimApp
-    participant Relayer
-    participant CelestiaProver
-    participant EVMProver
-    participant EVM
-    
-    %% Initial Transfer: SimApp to EVM
-    User->>SimApp: Submit MsgTransfer (ICS20)
-    SimApp->>SimApp: Execute transaction
-    Note over SimApp: Check balance & lock funds
-    SimApp->>SimApp: Store commitment in state
-    
-    %% State Transition Proof for EVM
-    SimApp-->>Relayer: Emit SendPacket events
-    Relayer->>CelestiaProver: Query state transition proof
-    CelestiaProver-->>Relayer: Return SP1 state transition proof
-    Relayer->>EVM: Submit MsgUpdateClient with state transition proof
-    EVM->>EVM: Verify SP1 proof
-    EVM->>EVM: Update Tendermint light client
-    
-    %% State Membership Proof for EVM
-    Relayer->>CelestiaProver: Query membership proof
-    CelestiaProver-->>Relayer: Return SP1 membership proof
-    Relayer->>EVM: Submit MsgRecvPacket with membership proof
-    EVM->>EVM: Verify receipt in SimApp state
-    EVM->>EVM: Mint tokens to recipient
-    EVM->>EVM: Store receipt
-    
-    %% Acknowledgement: EVM to SimApp
-    EVM-->>Relayer: Emit WriteAcknowledgement events
-    Relayer->>EVMProver: Query state transition proof
-    EVMProver-->>Relayer: Return Groth16 state transition proof
-    Relayer->>SimApp: Submit MsgUpdateClient with state transition proof
-    SimApp->>SimApp: Verify Groth16 proof
-    SimApp->>SimApp: Update EVM light client
-    
-    %% State Membership Proof for SimApp
-    Relayer->>EVMProver: Query membership proof
-    EVMProver-->>Relayer: Return Groth16 membership proof
-    Relayer->>SimApp: Submit MsgAcknowledgement with membership proof
-    SimApp->>SimApp: Verify receipt in EVM state
-    SimApp->>SimApp: Unlock or burn tokens based on ack
-    SimApp->>SimApp: Store acknowledgement
-```
-
-## Architecture
-
-```mermaid
-graph TD
-    subgraph "EVM Rollup"
-        RollupNode["Rollup Node"]
-        IBC["IBC Eureka Smart Contracts"]
-        Sequencer["Centralized Sequencer"]
-    end
-    
-    subgraph "Prover System"
-        EVMProver["EVM Prover Service"]
-        SP1Programs["SP1 Programs"]
-        SP1Programs --> BLEVM["blevm (Block Prover)"]
-        SP1Programs --> BLEVMAgg["blevm-aggregator"]
-    end
-    
-    subgraph "Indexing"
-        RollkitIndexer["Rollkit Indexer"]
-        BlockStorage["Block Data Storage"]
-    end
-    
-    subgraph "Data Sources"
-        CelestiaDA["Celestia DA"]
-        EVMState["EVM State"]
-    end
-    
-    subgraph "IBC Infrastructure"
-        Relayer["IBC Relayer"]
-        CelestiaProver["Celestia Prover"]
-    end
-    
-    %% Data flow connections
-    CelestiaDA -->|"Raw blocks"| RollkitIndexer
-    RollupNode -->|"Block execution data"| EVMState
-    RollkitIndexer -->|"Height to inclusion mapping"| BlockStorage
-    
-    EVMState -->|"State data"| EVMProver
-    BlockStorage -->|"Raw block data"| EVMProver
-    
-    EVMProver -->|"Uses"| BLEVM
-    EVMProver -->|"Uses"| BLEVMAgg
-    
-    Relayer -->|"ProveStateTransition request"| EVMProver
-    Relayer -->|"ProveStateMembership request"| EVMProver
-    EVMProver -->|"Groth16 proofs"| Relayer
-    
-    Relayer -->|"Submit proofs + packets"| IBC
-    Sequencer -->|"Transactions"| RollupNode
-```
-
-## Flow Overview
-
-The EVM Prover implements the Prover service protocol to provide zero-knowledge proofs for:
-1. State membership verification
-2. State transition verification
-
-These proofs are used within the IBC (Inter-Blockchain Communication) protocol to securely transfer assets between the EVM rollup and other chains.
-
-```mermaid
-graph TD
-    subgraph "State Transition Proof Flow"
-        RelayerST[Relayer]
-        EVMProverST[EVM Prover]
-        IndexerST[Rollkit Indexer]
-        BLEVMST[blevm SP1 Program]
-        BLEVMAggST[blevm-aggregator]
-        
-        RelayerST -->|"1. ProveStateTransition request"| EVMProverST
-        EVMProverST -->|"2. Query blocks in range"| IndexerST
-        IndexerST -->|"3. Return block data"| EVMProverST
-        EVMProverST -->|"4. Generate proofs for each block"| BLEVMST
-        BLEVMST -->|"5. Return BlevmOutputs"| EVMProverST
-        EVMProverST -->|"6. Aggregate proofs"| BLEVMAggST
-        BLEVMAggST -->|"7. Return BlevmAggOutput"| EVMProverST
-        EVMProverST -->|"8. Return proof response"| RelayerST
-    end
-    
-    subgraph "State Membership Proof Flow"
-        RelayerSM[Relayer]
-        EVMProverSM[EVM Prover]
-        IndexerSM[Rollkit Indexer]
-        BLEVMSM[blevm SP1 Program]
-        
-        RelayerSM -->|"1. ProveStateMembership request"| EVMProverSM
-        EVMProverSM -->|"2. Query block at height"| IndexerSM
-        IndexerSM -->|"3. Return block data"| EVMProverSM
-        EVMProverSM -->|"4. Generate proof with key path"| BLEVMSM
-        BLEVMSM -->|"5. Return BlevmOutput"| EVMProverSM
-        EVMProverSM -->|"6. Return proof response"| RelayerSM
-    end
-```
-
-## Prover Service
-
-The EVM Prover implements the following gRPC service:
-
-```protobuf
-service Prover {
-  rpc Info(InfoRequest) returns (InfoResponse);
-  rpc ProveStateTransition(ProveStateTransitionRequest) returns (ProveStateTransitionResponse);
-  rpc ProveStateMembership(ProveStateMembershipRequest) returns (ProveStateMembershipResponse);
-}
-```
-
-### Endpoints
-
-#### Info
-Returns information about the prover, including verifier keys.
-
-#### ProveStateTransition
-Generates a zero-knowledge proof of state transition for a given client ID (Tendermint light client contract address for EVM chains).
-
-#### ProveStateMembership
-Generates a zero-knowledge proof of state membership for a given client ID and key paths.
+The EVM Prover implements the Prover service for EVM rollups, creating zero-knowledge range proofs for state membership and state transitions. It uses the following SP1 programs to generate these range proofs.
 
 ## SP1 Programs
 
@@ -216,7 +48,6 @@ pub struct BlevmAggOutput {
     pub newest_height: u64,
 }
 ```
-
 ## Rollkit Indexer
 
 The current architecture uses an indexer for Rollkit which:
@@ -224,14 +55,14 @@ The current architecture uses an indexer for Rollkit which:
 - Stores raw block data submitted to Celestia
 - Provides these as inputs for proving inclusion
 
-This mapping is crucial for the EVM Prover to locate the correct Celestia blocks when generating proofs.
+This mapping is used by the EVM Prover to locate the Celestia inclusion block when generating proofs.
 
 ## Current Limitations and Future Work
 
 ### Current Limitations
 
-1. **Matching Inclusion and Execution Data**: The system for matching inclusion data with execution data is not yet implemented.
-2. **Sequencer Signature Verification**: Verification of sequencer signatures is pending implementation.
+1. **Matching Inclusion and Execution Data**: Matching inclusion data to execution data is not yet implemented.
+2. **Sequencer Signature Verification**: Verification of sequencer signatures is not yet implementated.
 
 ### Future Improvements
 
@@ -240,37 +71,6 @@ This mapping is crucial for the EVM Prover to locate the correct Celestia blocks
    - Verify proofs over a requested range in parallel
    - Improve throughput and reduce latency for proof generation
 
-2. **Enhanced Indexer**: Improve the indexer to provide more efficient lookups and support for additional metadata.
+2. **Remove Indexer**: The indexer is a stop-gap solution, in future Rollkit versions we can lookup the inclusion block more efficiently.
 
-3. **Optimized Proof Aggregation**: Implement more efficient algorithms for proof aggregation to reduce computational overhead.
-
-## Input Data for Block Proving
-
-```rust
-pub struct BlockProverInput {
-    pub inclusion_height: u64,
-    pub client_executor_input: Vec<u8>,
-    pub rollup_block: Vec<u8>,
-}
-```
-
-## Aggregation Interface
-
-### Input:
-```rust
-pub struct AggregationInput {
-    pub proof: SP1ProofWithPublicValues,
-    pub vk: SP1VerifyingKey,
-}
-```
-
-### Output:
-```rust
-pub struct AggregationOutput {
-    pub proof: SP1ProofWithPublicValues,
-}
-```
-
-## Integration with IBC
-
-The EVM Prover works in conjunction with the IBC Eureka Smart Contracts and Relayer to facilitate cross-chain communication and asset transfers. The proofs generated by the EVM Prover are used to verify state transitions and state membership across chains, ensuring security and integrity in cross-chain operations.
+3. **Optimized Proof Aggregation**: Implement logarithmic algorithm for proof aggregation to reduce computational overhead.

--- a/provers/evm-prover/ARCHITECTURE.md
+++ b/provers/evm-prover/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # EVM Prover
 
-The EVM Prover implements the Prover service for EVM rollups, creating zero-knowledge range proofs for state membership and state transitions. It uses the following SP1 programs to generate these range proofs.
+The EVM Prover implements the Prover service for EVM rollups, creating zero-knowledge range proofs for state transitions. It uses the following SP1 programs to generate these range proofs:
 
 ## SP1 Programs
 

--- a/provers/evm-prover/ARCHITECTURE.md
+++ b/provers/evm-prover/ARCHITECTURE.md
@@ -52,7 +52,7 @@ pub struct BlevmAggOutput {
 
 The current architecture uses an indexer for Rollkit which:
 - Maps EVM block heights to their inclusion heights in Celestia
-- Stores raw block data submitted to Celestia
+- Stores pointers i.e inclusion height, blob commitment to data submitted to Celestia
 - Provides these as inputs for proving inclusion
 
 This mapping is used by the EVM Prover to locate the Celestia inclusion block when generating proofs.

--- a/provers/evm-prover/ARCHITECTURE.md
+++ b/provers/evm-prover/ARCHITECTURE.md
@@ -1,0 +1,211 @@
+# EVM Prover
+
+The EVM Prover implements the Prover service for EVM rollups, creating zero-knowledge proofs for state membership and state transitions. It uses SP1 programs (`blevm` and `blevm-aggregator`) to generate ZK proofs of data inclusion in Celestia and EVM execution using the Rollup State Prover (RSP).
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "EVM Rollup"
+        RollupNode["Rollup Node"]
+        RETH["RETH"]
+        IBC["IBC Eureka Smart Contracts"]
+        Sequencer["Centralized Sequencer"]
+    end
+    
+    subgraph "Prover Services"
+        EVMProver["EVM Prover Service"]
+        CelestiaProver["Celestia Prover Service"]
+    end
+    
+    subgraph "Indexer"
+        RollkitIndexer["Rollkit Indexer"]
+    end
+    
+    subgraph "SP1 Programs"
+        BLEVM["blevm SP1 Program"]
+        BLEVMAgg["blevm-aggregator SP1 Program"]
+    end
+    
+    subgraph "Data Availability"
+        CelestiaDA["Celestia DA"]
+    end
+    
+    subgraph "IBC"
+        Relayer["Relayer"]
+    end
+    
+    RollupNode -- "EVM State" --> EVMProver
+    CelestiaDA -- "Block Data" --> RollkitIndexer
+    RollkitIndexer -- "Height to Inclusion Mapping" --> EVMProver
+    
+    EVMProver -- "Uses" --> BLEVM
+    EVMProver -- "Uses" --> BLEVMAgg
+    
+    Relayer -- "Requests Groth16 Proofs" --> EVMProver
+    EVMProver -- "Returns Proofs" --> Relayer
+    
+    Relayer -- "Submits Proofs + IBC Packets" --> IBC
+```
+
+## Flow Overview
+
+The EVM Prover implements the Prover service protocol to provide zero-knowledge proofs for:
+1. State membership verification
+2. State transition verification
+
+These proofs are used within the IBC (Inter-Blockchain Communication) protocol to securely transfer assets between the EVM rollup and other chains.
+
+```mermaid
+sequenceDiagram
+    participant Relayer
+    participant EVMProver as EVM Prover
+    participant RollkitIndexer as Rollkit Indexer
+    participant BLEVM as blevm SP1 Program
+    participant BLEVMAgg as blevm-aggregator SP1 Program
+    participant CelestiaDA as Celestia DA
+    
+    Relayer->>EVMProver: ProveStateTransition request
+    EVMProver->>RollkitIndexer: Query height to inclusion mapping
+    RollkitIndexer-->>EVMProver: Return mapping data
+    EVMProver->>BLEVM: Generate inclusion proofs
+    BLEVM-->>EVMProver: Return BlevmOutput
+    EVMProver->>BLEVMAgg: Aggregate proofs
+    BLEVMAgg-->>EVMProver: Return BlevmAggOutput
+    EVMProver-->>Relayer: ProveStateTransition response
+    
+    Relayer->>EVMProver: ProveStateMembership request
+    EVMProver->>RollkitIndexer: Query height to inclusion mapping
+    RollkitIndexer-->>EVMProver: Return mapping data
+    EVMProver->>BLEVM: Generate inclusion + membership proofs
+    BLEVM-->>EVMProver: Return BlevmOutput with membership proof
+    EVMProver-->>Relayer: ProveStateMembership response
+```
+
+## Prover Service
+
+The EVM Prover implements the following gRPC service:
+
+```protobuf
+service Prover {
+  rpc Info(InfoRequest) returns (InfoResponse);
+  rpc ProveStateTransition(ProveStateTransitionRequest) returns (ProveStateTransitionResponse);
+  rpc ProveStateMembership(ProveStateMembershipRequest) returns (ProveStateMembershipResponse);
+}
+```
+
+### Endpoints
+
+#### Info
+Returns information about the prover, including verifier keys.
+
+#### ProveStateTransition
+Generates a zero-knowledge proof of state transition for a given client ID (Tendermint light client contract address for EVM chains).
+
+#### ProveStateMembership
+Generates a zero-knowledge proof of state membership for a given client ID and key paths.
+
+## SP1 Programs
+
+### blevm
+
+The `blevm` SP1 program generates proofs of data inclusion and execution for single EVM blocks.
+
+#### Inputs:
+- `KeccakInclusionToDataRootProofInput`: Data for inclusion proof
+- `EthClientExecutorInput`: Data for EVM execution
+- `celestia_header_hash`: Celestia block header hash
+- `data_hash_bytes`: Hash of the block data
+- `proof_data_hash_to_celestia_hash`: Merkle proof connecting data hash to Celestia hash
+
+#### Output:
+```rust
+pub struct BlevmOutput {
+    pub blob_commitment: [u8; 32],
+    pub header_hash: [u8; 32],
+    pub prev_header_hash: [u8; 32],
+    pub height: u64,
+    pub gas_used: u64,
+    pub beneficiary: [u8; 20],
+    pub state_root: [u8; 32],
+    pub celestia_header_hash: [u8; 32],
+}
+```
+
+### blevm-aggregator
+
+The `blevm-aggregator` SP1 program aggregates multiple block proofs to create a proof over a range of blocks.
+
+#### Inputs:
+- `vkeys`: Verification keys for the proofs to aggregate
+- `public_values`: Public values from the proofs to aggregate
+- Proofs (automatically input)
+
+#### Output:
+```rust
+pub struct BlevmAggOutput {
+    pub newest_header_hash: [u8; 32],
+    pub oldest_header_hash: [u8; 32],
+    pub celestia_header_hashes: Vec<[u8; 32]>,
+    pub newest_state_root: [u8; 32],
+    pub newest_height: u64,
+}
+```
+
+## Rollkit Indexer
+
+The current architecture uses an indexer for Rollkit which:
+- Maps EVM block heights to their inclusion heights in Celestia
+- Stores raw block data submitted to Celestia
+- Provides these as inputs for proving inclusion
+
+This mapping is crucial for the EVM Prover to locate the correct Celestia blocks when generating proofs.
+
+## Current Limitations and Future Work
+
+### Current Limitations
+
+1. **Matching Inclusion and Execution Data**: The system for matching inclusion data with execution data is not yet implemented.
+2. **Sequencer Signature Verification**: Verification of sequencer signatures is pending implementation.
+
+### Future Improvements
+
+1. **Modular Proofs**: In the future, we should implement modular proofs that can:
+   - Create inclusion, execution, and signature verification proofs in parallel
+   - Verify proofs over a requested range in parallel
+   - Improve throughput and reduce latency for proof generation
+
+2. **Enhanced Indexer**: Improve the indexer to provide more efficient lookups and support for additional metadata.
+
+3. **Optimized Proof Aggregation**: Implement more efficient algorithms for proof aggregation to reduce computational overhead.
+
+## Input Data for Block Proving
+
+```rust
+pub struct BlockProverInput {
+    pub inclusion_height: u64,
+    pub client_executor_input: Vec<u8>,
+    pub rollup_block: Vec<u8>,
+}
+```
+
+## Aggregation Interface
+
+### Input:
+```rust
+pub struct AggregationInput {
+    pub proof: SP1ProofWithPublicValues,
+    pub vk: SP1VerifyingKey,
+}
+```
+
+### Output:
+```rust
+pub struct AggregationOutput {
+    pub proof: SP1ProofWithPublicValues,
+}
+```
+
+## Integration with IBC
+
+The EVM Prover works in conjunction with the IBC Eureka Smart Contracts and Relayer to facilitate cross-chain communication and asset transfers. The proofs generated by the EVM Prover are used to verify state transitions and state membership across chains, ensuring security and integrity in cross-chain operations.

--- a/provers/evm-prover/ARCHITECTURE.md
+++ b/provers/evm-prover/ARCHITECTURE.md
@@ -9,11 +9,11 @@ The EVM Prover implements the Prover service for EVM rollups, creating zero-know
 The `blevm` SP1 program generates proofs of data inclusion and execution for single EVM blocks.
 
 #### Inputs:
-- `KeccakInclusionToDataRootProofInput`: Data for inclusion proof
-- `EthClientExecutorInput`: Data for EVM execution
-- `celestia_header_hash`: Celestia block header hash
-- `data_hash_bytes`: Hash of the block data
-- `proof_data_hash_to_celestia_hash`: Merkle proof connecting data hash to Celestia hash
+- `KeccakInclusionToDataRootProofInput`: Data for inclusion proof. This proof proves that the EVM raw block data was published as a blob and included in a Celestia block.
+- `EthClientExecutorInput`: Data for EVM execution, see [rsp.](https://github.com/succinctlabs/rsp/blob/5cd792c12c663d6c9feb54849c6df611029b5863/crates/executor/client/src/io.rs#L27-L56)
+- `celestia_header_hash`: Celestia block header hash.
+- `data_hash_bytes`: Data hash of the transactions in the Celestia header.
+- `proof_data_hash_to_celestia_hash`: Merkle proof connecting data hash to Celestia header hash.
 
 #### Output:
 ```rust

--- a/provers/evm-prover/README.md
+++ b/provers/evm-prover/README.md
@@ -45,3 +45,7 @@ For reference in mock mode, the proof generation takes ~15 minutes for aggregati
 ## Protobuf
 
 gRPC depends on proto defined types. These are stored in `proto/prover/v1` from the root directory.
+
+## Architecture
+
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for more information.


### PR DESCRIPTION
## Overview

This PR adds a document explaining the current architecture of the evm-prover.