### PR TITLE
fix: retry indexer request

### DIFF
--- a/provers/evm-prover/src/main.rs
+++ b/provers/evm-prover/src/main.rs
@@ -171,10 +171,24 @@ impl Prover for ProverService {
         );
 
         for height in start_height..=end_height {
-            let (inclusion_height, blob_commitment) =
-                get_inclusion_height(self.indexer_url.clone(), height)
-                    .await
-                    .unwrap();
+            let (inclusion_height, blob_commitment) = {
+                let mut retries = 0;
+                const MAX_RETRIES: u32 = 3;
+                const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+                loop {
+                    match get_inclusion_height(self.indexer_url.clone(), height).await {
+                        Ok(result) => break result,
+                        Err(blevm_prover::indexer::IndexerError::BlockNotFound) if retries < MAX_RETRIES => {
+                            retries += 1;
+                            println!("Block not found for height {}, retrying ({}/{})...", height, retries, MAX_RETRIES);
+                            tokio::time::sleep(RETRY_DELAY).await;
+                            continue;
+                        }
+                        Err(e) => return Err(Status::internal(format!("Failed to get inclusion height: {}", e))),
+                    }
+                }
+            };
             let client_executor_input = generate_client_input(
                 self.evm_rpc_url.clone(),
                 height,

--- a/provers/evm-prover/src/main.rs
+++ b/provers/evm-prover/src/main.rs
@@ -179,13 +179,23 @@ impl Prover for ProverService {
                 loop {
                     match get_inclusion_height(self.indexer_url.clone(), height).await {
                         Ok(result) => break result,
-                        Err(blevm_prover::indexer::IndexerError::BlockNotFound) if retries < MAX_RETRIES => {
+                        Err(blevm_prover::indexer::IndexerError::BlockNotFound)
+                            if retries < MAX_RETRIES =>
+                        {
                             retries += 1;
-                            println!("Block not found for height {}, retrying ({}/{})...", height, retries, MAX_RETRIES);
+                            println!(
+                                "Block not found for height {}, retrying ({}/{})...",
+                                height, retries, MAX_RETRIES
+                            );
                             tokio::time::sleep(RETRY_DELAY).await;
                             continue;
                         }
-                        Err(e) => return Err(Status::internal(format!("Failed to get inclusion height: {}", e))),
+                        Err(e) => {
+                            return Err(Status::internal(format!(
+                                "Failed to get inclusion height: {}",
+                                e
+                            )))
+                        }
                     }
                 }
             };

--- a/provers/evm-prover/src/main.rs
+++ b/provers/evm-prover/src/main.rs
@@ -173,7 +173,7 @@ impl Prover for ProverService {
         for height in start_height..=end_height {
             let (inclusion_height, blob_commitment) = {
                 let mut retries = 0;
-                const MAX_RETRIES: u32 = 3;
+                const MAX_RETRIES: u32 = 10;
                 const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
                 loop {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-zkevm-ibc-demo/issues/258

## Testing

I verified this works by re-running `make demo`. Previously the evm-prover would panic. Now it retries:

```
Block not found for height 14, retrying (1/3)...
indexer: requesting url - http://127.0.0.1:8080/inclusion_height/14
indexer: requesting url - http://127.0.0.1:8080/inclusion_height/15
indexer: requesting url - http://127.0.0.1:8080/inclusion_height/16
Block not found for height 16, retrying (1/3)...
indexer: requesting url - http://127.0.0.1:8080/inclusion_height/16
Block not found for height 16, retrying (2/3)...
indexer: requesting url - http://127.0.0.1:8080/inclusion_height/16
generating aggregation proof, size: 14
```