### PR TITLE
build: update golangci-lint-action to v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - uses: golangci/golangci-lint-action@v6.1.1
+      - uses: golangci/golangci-lint-action@v8.1.1
         with:
           version: v1.64.6
           args: --timeout 10m


### PR DESCRIPTION
Maintenance update: switch all jobs to golangci-lint-action@v8 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v8.0.0 release](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0).